### PR TITLE
fix custom ordering initialization

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -308,6 +308,7 @@ function useClientSideOrder<T extends { _id: string }>(
   items: T[],
 ) {
   const [orderIds, setOrderIds] = useState<string[]>([]);
+  const [hasLoadedOrder, setHasLoadedOrder] = useState(false);
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [draggedSize, setDraggedSize] = useState<{
     width: number;
@@ -316,12 +317,14 @@ function useClientSideOrder<T extends { _id: string }>(
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
 
   useEffect(() => {
+    setHasLoadedOrder(false);
     try {
       const raw = localStorage.getItem(storageKey);
       setOrderIds(raw ? (JSON.parse(raw) as string[]) : []);
     } catch {
       setOrderIds([]);
     }
+    setHasLoadedOrder(true);
   }, [storageKey]);
 
   const persist = useCallback(
@@ -330,7 +333,6 @@ function useClientSideOrder<T extends { _id: string }>(
       try {
         localStorage.setItem(storageKey, JSON.stringify(ids));
       } catch {
-        // e.g. private browsing / storage full — safe to ignore, order just
         // won't survive a refresh.
       }
     },
@@ -349,6 +351,7 @@ function useClientSideOrder<T extends { _id: string }>(
   }, [items, orderIds]);
 
   useEffect(() => {
+    if (!hasLoadedOrder) return;
     if (items.length === 0) return;
     const ids = orderedItems.map((item) => item._id);
     const unchanged =
@@ -356,7 +359,7 @@ function useClientSideOrder<T extends { _id: string }>(
       ids.every((id, i) => id === orderIds[i]);
     if (!unchanged) persist(ids);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orderedItems]);
+  }, [orderedItems, hasLoadedOrder]);
 
   const handleDragStart = useCallback(
     (id: string, rect?: { width: number; height: number }) => {
@@ -949,12 +952,14 @@ export default function WorkingSpacePageClient({
   const cached = workspacePageMemoryCache.get(
     workingSpaceId as unknown as string,
   );
-  const workspaceQuery = useQuery(api.workingSpaces.getWorkingSpaceById, {
-    _id: workingSpaceId,
-  }) as any;
-  const tablesQuery = useQuery(api.notesTables.getTables, {
-    workingSpaceId,
-  }) as any;
+  const workspaceQuery = useQuery(
+    api.workingSpaces.getWorkingSpaceById,
+    workingSpaceId ? { _id: workingSpaceId } : "skip",
+  ) as any;
+  const tablesQuery = useQuery(
+    api.notesTables.getTables,
+    workingSpaceId ? { workingSpaceId } : "skip",
+  ) as any;
 
   const workspace = workspaceQuery ?? cached?.workspace;
   const workingSpacesSlug: string | undefined =


### PR DESCRIPTION
## what changed

* Added a `hasLoadedOrder` state to track whether the saved custom order has been loaded from `localStorage`.
* Prevented the ordering logic from persisting items until the saved order has finished loading.
* Reset the loading state whenever the storage key changes, such as when switching tables.
* Updated the Convex queries to use `"skip"` when `workingSpaceId` isn't available yet.

There was a potential race condition where the ordering logic could run before the saved order from `localStorage` had finished loading. That could cause the current item order to be written back to storage and overwrite the user's previously saved custom order.

The Convex queries also didn't need to run when there was no valid `workingSpaceId`, so skipping them in that state avoids unnecessary or invalid queries.

##  now

Custom note ordering is now safer when switching between tables or loading a workspace. The saved order is loaded first before the hook tries to persist anything, preventing existing custom orders from being accidentally overwritten.

The workspace queries are also more defensive and only run when a valid workspace ID is available.
