### PR TITLE
polish toggle action tooltips

### DIFF
--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -289,7 +289,7 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
           <TooltipContent
             side="bottom"
             align="start"
-            sideOffset={10}
+            sideOffset={5}
             className="text-xs font-bold py-0.5 px-1.5 !rounded-none"
           >
             <p>{isOpen ? "Collapse toggle action" : "Expand toggle action"}</p>
@@ -328,7 +328,7 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
               <button
                 type="button"
                 style={contrastStyle}
-                className="min-w-0 truncate text-left text-sm cursor-text font-medium text-muted-foreground"
+                className="min-w-0 truncate text-left text-sm cursor-text font-medium text--foreground"
                 onDoubleClick={handleDoubleClick}
                 aria-label="Double click to rename"
                 {...titleTooltip.triggerProps}
@@ -340,7 +340,7 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
             <TooltipContent
               side="bottom"
               align="start"
-              sideOffset={10}
+              sideOffset={5}
               className="text-xs font-bold py-0.5 px-1.5 !rounded-none"
             >
               <p>Double click to rename</p>


### PR DESCRIPTION
## what changed
before : 
<img width="872" height="162" alt="image" src="https://github.com/user-attachments/assets/7dd040d1-34f1-461d-a3f3-3fb348d130f3" />

after : 
<img width="946" height="141" alt="image" src="https://github.com/user-attachments/assets/c2664a76-c44b-41aa-8cad-ec9c8d4ebf10" />


* Reduced the tooltip `sideOffset` from `10px` to `5px` for the toggle action and rename tooltips.
* Updated the toggle action title text styling to use the foreground color.

The tooltips were sitting a little too far away from their triggers. Reducing the offset brings them closer and makes the interaction feel more connected to the button or text being described.

The title text color was also adjusted to better match the foreground styling used by the rest of the component.

Toggle action tooltips now appear closer to their triggers, making them feel more responsive and less disconnected from the controls. The toggle title also has a clearer foreground color treatment.
