### PR TITLE
polish home page loading state

### DIFF
--- a/app/home/HomePageClient.tsx
+++ b/app/home/HomePageClient.tsx
@@ -142,7 +142,7 @@ export default function HomePageClient() {
   return (
     <MaxWContainer className="relative">
       {/* Hero Section */}
-      <div className="overflow-hidden py-6 mb-16">
+      <div className="overflow-hidden py-2 mb-14">
         <header className="flex flex-col justify-center items-start gap-2 relative">
           <h1 className="text-3xl sm:text-5xl font-bold text-primary">
             {viewer?.name ? (
@@ -159,7 +159,11 @@ export default function HomePageClient() {
                 }`}
               </>
             ) : (
-              <SkeletonTextAnimation className=" mx-0 min-w-60 h-14" />
+              <span className="flex justify-center items-center gap-0.5">
+                <SkeletonTextAnimation className=" mx-0 min-w-20 h-10" />
+                ,
+                <SkeletonTextAnimation className=" mx-0 min-w-60 h-10" />
+              </span>
             )}
           </h1>
           <p className="text-white/90 text-md ">


### PR DESCRIPTION
## what changed

* Reduced the hero section's vertical padding from `py-6` to `py-2`.
* Reduced the hero bottom margin from `mb-16` to `mb-14`.
* Updated the loading skeleton for the greeting to better match the actual text structure.
* Split the skeleton into separate parts for the user's name and the workspace/content text, with the comma rendered between them.
* Reduced the skeleton heights to better match the current heading layout.

The hero section had a little too much vertical space, making the top of the home page feel more spread out than necessary. The loading state also didn't accurately represent the final greeting because it used a single large skeleton.