### PR TITLE
add move actions for links and tables

### DIFF
--- a/components/home-components/LinkSettings.tsx
+++ b/components/home-components/LinkSettings.tsx
@@ -2,10 +2,11 @@
 
 import { useCallback, useState } from "react";
 import { useMutation } from "convex/react";
-import { ExternalLink, Pin } from "lucide-react";
+import { ExternalLink, FileOutput, Pin } from "lucide-react";
 import { FaEllipsis, FaEllipsisVertical, FaRegTrashCan } from "react-icons/fa6";
 import type { Id } from "@/convex/_generated/dataModel";
 import { api } from "@/convex/_generated/api";
+import { useQuery } from "@/cache/useQuery";
 import { cn } from "@/lib/utils";
 import {
   AlertDialog,
@@ -31,6 +32,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
+import MoveLinkDialog from "./MoveLinksDialog";
 
 interface LinkSettingsProps {
   linkId: Id<"links">;
@@ -80,10 +82,13 @@ export default function LinkSettings({
 }: LinkSettingsProps) {
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
   const tooltip = useHoverTooltip(100);
 
   const updateLink = useMutation(api.links.updateLink);
   const deleteLink = useMutation(api.links.deleteLink);
+
+  const link = useQuery(api.links.getLinkById, { _id: linkId });
 
   const handleFavoritePin = useCallback(async () => {
     await updateLink({
@@ -154,7 +159,7 @@ export default function LinkSettings({
             align={tooltipContentAlign}
             className="text-xs px-1.5 py-1"
           >
-            Pin, Open, Delete
+            Pin, Open, Move, Delete
           </TooltipContent>
         </Tooltip>
 
@@ -185,6 +190,19 @@ export default function LinkSettings({
                 <ExternalLink size={14} className="text-muted-foreground" />
                 Open Link
               </a>
+            </Button>
+
+            <Button
+              variant="SidebarMenuButton"
+              className="w-full h-8 px-2 text-sm"
+              onClick={() => {
+                setOpen(false);
+                setIsMoveDialogOpen(true);
+              }}
+              aria-label="move-link"
+            >
+              <FileOutput size={14} className="text-muted-foreground" />
+              Move Link
             </Button>
 
             <DropdownMenuSeparator />
@@ -236,6 +254,17 @@ export default function LinkSettings({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <MoveLinkDialog
+        open={isMoveDialogOpen}
+        onOpenChange={setIsMoveDialogOpen}
+        link={{
+          _id: linkId,
+          title: linkTitle,
+          workingSpaceId: link?.workingSpaceId,
+          notesTableId: link?.notesTableId,
+        }}
+      />
     </>
   );
 }

--- a/components/home-components/MoveLinksDialog.tsx
+++ b/components/home-components/MoveLinksDialog.tsx
@@ -1,21 +1,19 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
 import { useMutation } from "convex/react";
 import {
   ChevronRight,
+  FileSymlink,
   Folder,
   FolderOpen,
   Plus,
   Search,
-  FileSymlink,
 } from "lucide-react";
-import { useToast } from "@/hooks/use-toast";
-import { toast } from "sonner";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { useQuery } from "@/cache/useQuery";
+import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -29,13 +27,13 @@ import {
 } from "@/components/ui/dialog";
 import CreateTableBtn from "./CreateTableBtn";
 import IntentPrefetchLink from "../IntentPrefetchLink";
-interface MoveNoteDialogProps {
+
+interface MoveLinkDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  note: {
-    _id: Id<"notes">;
+  link: {
+    _id: Id<"links">;
     title?: string;
-    slug?: string;
     workingSpaceId?: Id<"workingSpaces">;
     notesTableId?: Id<"notesTables">;
   };
@@ -58,12 +56,12 @@ function HighlightedText({ text, query }: { text: string; query: string }) {
   );
 }
 
-export default function MoveNoteDialog({
+export default function MoveLinkDialog({
   open,
   onOpenChange,
-  note,
-}: MoveNoteDialogProps) {
-  const router = useRouter();
+  link,
+}: MoveLinkDialogProps) {
+  const { toast } = useToast();
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -72,37 +70,26 @@ export default function MoveNoteDialog({
   );
   const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
   const [movingTableId, setMovingTableId] = useState<string | null>(null);
-  const { toast } = useToast();
 
   const moveTargets = useQuery(api.notes.getWorkspaceTreeForMove, {
     searchQuery: debouncedQuery || undefined,
   }) as any[] | undefined;
 
-  const moveNote = useMutation(api.notes.moveNote).withOptimisticUpdate(
+  const moveLink = useMutation(api.links.moveLink).withOptimisticUpdate(
     (local, args) => {
-      const currentNote = local.getQuery(api.notes.getNoteById, {
+      const currentLink = local.getQuery(api.links.getLinkById, {
         _id: args._id,
       });
 
-      if (!currentNote) return;
-
-      const targets =
-        local.getQuery(api.notes.getWorkspaceTreeForMove, {
-          searchQuery: undefined,
-        }) ?? [];
-      const targetWorkspace = targets.find(
-        (workspace: any) => workspace._id === args.targetWorkingSpaceId,
-      );
+      if (!currentLink) return;
 
       local.setQuery(
-        api.notes.getNoteById,
+        api.links.getLinkById,
         { _id: args._id },
         {
-          ...currentNote,
+          ...currentLink,
           workingSpaceId: args.targetWorkingSpaceId,
           notesTableId: args.targetNotesTableId,
-          workingSpacesSlug:
-            targetWorkspace?.slug ?? currentNote.workingSpacesSlug,
           updatedAt: Date.now(),
         },
       );
@@ -124,7 +111,7 @@ export default function MoveNoteDialog({
     setQuery("");
     setDebouncedQuery("");
     setExpandedWorkspaceIds(
-      note.workingSpaceId ? [String(note.workingSpaceId)] : [],
+      link.workingSpaceId ? [String(link.workingSpaceId)] : [],
     );
     setIsCreatingWorkspace(false);
     setMovingTableId(null);
@@ -134,7 +121,7 @@ export default function MoveNoteDialog({
     }, 20);
 
     return () => clearTimeout(timer);
-  }, [open, note.workingSpaceId]);
+  }, [open, link.workingSpaceId]);
 
   useEffect(() => {
     if (!debouncedQuery || !moveTargets) return;
@@ -178,21 +165,22 @@ export default function MoveNoteDialog({
   ) => {
     try {
       setMovingTableId(String(targetNotesTableId));
-      const result = await moveNote({
-        _id: note._id,
+      const result = await moveLink({
+        _id: link._id,
         targetWorkingSpaceId,
         targetNotesTableId,
       });
       onOpenChange(false);
+
       toast({
         variant: "default",
-        title: "Note moved successfully ",
-        description: "hey go and take a look at your stuff !!",
+        title: "Link moved successfully",
+        description: "Jump straight to the link in its new location.",
         action: (
-          <Button variant="secondary" className="px-3 h-8" size="sm">
+          <Button variant="secondary" className="px-3 h-8" size="sm" asChild>
             <IntentPrefetchLink
-              href={`/home/${result.workingSpaceId}/${result.slug}?id=${note._id}`}
-              className="flex justify-center items-center gap-2 text-xs"
+              href={`/home/${result.workingSpaceId}?linkId=${link._id}`}
+              className="flex justify-center items-center gap-2"
             >
               <FileSymlink size={16} />
               Checkout
@@ -201,10 +189,10 @@ export default function MoveNoteDialog({
         ),
       });
     } catch (error) {
-      console.error(" Failed to move note:", error);
+      console.error("Failed to move link:", error);
       toast({
         variant: "destructive",
-        title: "Failed to move note",
+        title: "Failed to move link",
         description: "Try again later",
       });
     } finally {
@@ -217,10 +205,10 @@ export default function MoveNoteDialog({
       <DialogContent className="p-0 overflow-hidden bg-muted border-border md:min-w-[500px] gap-0 shadow-2xl">
         <DialogHeader className="px-5 pt-4 pb-3 border-b border-border">
           <p className="text-[10px] font-semibold uppercase tracking-widest text-foreground mb-1">
-            Move note
+            Move link
           </p>
           <DialogTitle className="text-[15px] font-medium text-foreground leading-snug">
-            {note.title || "Untitled"}
+            {link.title || "Untitled"}
           </DialogTitle>
           <DialogDescription className="text-xs text-muted-foreground mt-0.5">
             Select a destination table in this workspace or any other workspace.
@@ -273,7 +261,7 @@ export default function MoveNoteDialog({
                   : "No workspaces found"}
               </p>
               <p className="mt-1">
-                Create a workspace or table, then move this note there.
+                Create a workspace or table, then move this link there.
               </p>
             </div>
           ) : (
@@ -316,7 +304,7 @@ export default function MoveNoteDialog({
                     {isExpanded && (
                       <div className="space-y-0.5 px-1 py-1">
                         {tables.length === 0 ? (
-                          <div className=" flex flex-col justify-center items-center gap-2 app-radius-lg mx-2 py-3 bg-card text-xs text-muted-foreground/60 text-center">
+                          <div className="flex flex-col justify-center items-center gap-2 app-radius-lg mx-2 py-3 bg-card text-xs text-muted-foreground/60 text-center">
                             No tables in this workspace yet.
                             <CreateTableBtn
                               workingSpaceId={workspace._id}
@@ -336,8 +324,8 @@ export default function MoveNoteDialog({
                         ) : (
                           tables.map((table: any) => {
                             const isCurrentTarget =
-                              note.workingSpaceId === workspace._id &&
-                              note.notesTableId === table._id;
+                              link.workingSpaceId === workspace._id &&
+                              link.notesTableId === table._id;
                             const isMoving =
                               movingTableId === String(table._id);
 
@@ -353,12 +341,11 @@ export default function MoveNoteDialog({
                                     handleMove(workspace._id, table._id)
                                   }
                                   disabled={isCurrentTarget || isMoving}
-                                  aria-label=" handle-move-target"
                                   className={cn(
                                     "flex w-full items-center justify-between app-radius-lg mx-4 px-2 py-2 text-left transition-colors",
                                     isCurrentTarget
                                       ? "cursor-not-allowed bg-muted"
-                                      : " hover:bg-border",
+                                      : "hover:bg-border",
                                   )}
                                 >
                                   <div className="flex min-w-0 items-center gap-2">

--- a/components/home-components/MovePdfDialog.tsx
+++ b/components/home-components/MovePdfDialog.tsx
@@ -72,7 +72,7 @@ export default function MovePdfDialog({
   const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
   const [movingTableId, setMovingTableId] = useState<string | null>(null);
 
-  const moveTargets = useQuery(api.notes.getWorkspaceTree, {
+  const moveTargets = useQuery(api.notes.getWorkspaceTreeForMove, {
     searchQuery: debouncedQuery || undefined,
   }) as any[] | undefined;
 

--- a/components/home-components/MoveTableDialog.tsx
+++ b/components/home-components/MoveTableDialog.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useMutation } from "convex/react";
+import { FileSymlink, Folder, Plus, Search } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { useQuery } from "@/cache/useQuery";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import LoadingAnimation from "@/components/ui/LoadingAnimation";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import IntentPrefetchLink from "../IntentPrefetchLink";
+
+interface MoveTableDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  table: {
+    _id: Id<"notesTables">;
+    name?: string;
+    workingSpaceId: Id<"workingSpaces">;
+  };
+}
+
+function HighlightedText({ text, query }: { text: string; query: string }) {
+  if (!query) return <>{text}</>;
+
+  const index = text.toLowerCase().indexOf(query.toLowerCase());
+  if (index === -1) return <>{text}</>;
+
+  return (
+    <>
+      {text.slice(0, index)}
+      <span className="bg-primary/15 text-primary font-semibold">
+        {text.slice(index, index + query.length)}
+      </span>
+      {text.slice(index + query.length)}
+    </>
+  );
+}
+
+export default function MoveTableDialog({
+  open,
+  onOpenChange,
+  table,
+}: MoveTableDialogProps) {
+  const { toast } = useToast();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
+  const [movingWorkspaceId, setMovingWorkspaceId] = useState<string | null>(
+    null,
+  );
+
+  // A table's destination is a workspace itself, so this uses a flat
+  // workspace list rather than the workspace > table tree used by
+  // MoveNoteDialog / MovePdfDialog / MoveLinkDialog.
+  const moveTargets = useQuery(api.notesTables.getWorkspacesForMove, {
+    searchQuery: debouncedQuery || undefined,
+  }) as any[] | undefined;
+
+  const moveTable = useMutation(api.notesTables.moveTable).withOptimisticUpdate(
+    (local, args) => {
+      const currentTable = local.getQuery(api.notesTables.getTableById, {
+        _id: args._id,
+      });
+
+      if (!currentTable) return;
+
+      local.setQuery(
+        api.notesTables.getTableById,
+        { _id: args._id },
+        {
+          ...currentTable,
+          workingSpaceId: args.targetWorkingSpaceId,
+          updatedAt: Date.now(),
+        },
+      );
+    },
+  );
+  const createWorkingSpace = useMutation(api.workingSpaces.createWorkingSpace);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(query);
+    }, 250);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setQuery("");
+    setDebouncedQuery("");
+    setIsCreatingWorkspace(false);
+    setMovingWorkspaceId(null);
+
+    const timer = setTimeout(() => {
+      searchInputRef.current?.focus();
+    }, 20);
+
+    return () => clearTimeout(timer);
+  }, [open]);
+
+  const hasResults = (moveTargets?.length ?? 0) > 0;
+
+  const handleCreateWorkspace = async () => {
+    try {
+      setIsCreatingWorkspace(true);
+      await createWorkingSpace({ name: "Untitled" });
+    } catch (error) {
+      console.error("Failed to create workspace:", error);
+    } finally {
+      setIsCreatingWorkspace(false);
+    }
+  };
+
+  const handleMove = async (targetWorkingSpaceId: Id<"workingSpaces">) => {
+    try {
+      setMovingWorkspaceId(String(targetWorkingSpaceId));
+      const result = await moveTable({
+        _id: table._id,
+        targetWorkingSpaceId,
+      });
+      onOpenChange(false);
+      toast({
+        variant: "default",
+        title: "Table moved successfully",
+        description: "Everything inside moved with it.",
+        action: (
+          <Button variant="secondary" className="px-3 h-8" size="sm" asChild>
+            <IntentPrefetchLink
+              href={`/home/${result.workingSpaceId}?tableId=${table._id}`}
+              className="flex justify-center items-center gap-2 text-xs"
+            >
+              <FileSymlink size={16} />
+              Checkout
+            </IntentPrefetchLink>
+          </Button>
+        ),
+      });
+    } catch (error) {
+      console.error("Failed to move table:", error);
+      toast({
+        variant: "destructive",
+        title: "Failed to move table",
+        description: "Try again later",
+      });
+    } finally {
+      setMovingWorkspaceId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="p-0 overflow-hidden bg-muted border-border md:min-w-[500px] gap-0 shadow-2xl">
+        <DialogHeader className="px-5 pt-4 pb-3 border-b border-border">
+          <p className="text-[10px] font-semibold uppercase tracking-widest text-foreground mb-1">
+            Move table
+          </p>
+          <DialogTitle className="text-[15px] font-medium text-foreground leading-snug">
+            {table.name || "Untitled"}
+          </DialogTitle>
+          <DialogDescription className="text-xs text-muted-foreground mt-0.5">
+            Select a destination workspace. Notes, uploads, and links inside
+            this table move with it.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-1 bg-muted">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <Input
+              ref={searchInputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search workspaces..."
+              className="border-none px-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 text-sm bg-transparent"
+            />
+          </div>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleCreateWorkspace}
+            disabled={isCreatingWorkspace}
+            className="gap-1 text-xs px-2 h-8"
+          >
+            {isCreatingWorkspace ? (
+              <LoadingAnimation className="h-4 w-4 text-primary" />
+            ) : (
+              <Plus className="h-4 w-4" />
+            )}
+            Workspace
+          </Button>
+        </div>
+
+        <div className="min-h-[320px] max-h-[350px] overflow-y-auto [&::-webkit-scrollbar]:w-[0.4rem] scrollbar-gutter-stable [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent p-3 bg-card">
+          {moveTargets === undefined ? (
+            <div className="space-y-2 p-2">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="h-10 app-radius-lg bg-border animate-pulse"
+                />
+              ))}
+            </div>
+          ) : !hasResults ? (
+            <div className="flex min-h-[360px] flex-col items-center justify-center text-center text-sm text-muted-foreground">
+              <Folder className="mb-4 h-10 w-10 text-muted-foreground" />
+              <p className="font-medium text-foreground">
+                {debouncedQuery
+                  ? `No workspaces found for "${debouncedQuery}"`
+                  : "No workspaces found"}
+              </p>
+              <p className="mt-1">
+                Create a workspace to move this table there.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-0.5">
+              {moveTargets!.map((workspace) => {
+                const isCurrentTarget = table.workingSpaceId === workspace._id;
+                const isMoving = movingWorkspaceId === String(workspace._id);
+
+                return (
+                  <button
+                    key={workspace._id}
+                    type="button"
+                    onClick={() => handleMove(workspace._id)}
+                    disabled={isCurrentTarget || isMoving}
+                    className={cn(
+                      "flex w-full items-center justify-between app-radius-lg px-2 py-2 text-left transition-colors",
+                      isCurrentTarget
+                        ? "cursor-not-allowed bg-muted"
+                        : "hover:bg-border",
+                    )}
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      <span className="truncate text-sm font-medium text-foreground">
+                        <HighlightedText
+                          text={workspace.name || "Untitled"}
+                          query={debouncedQuery}
+                        />
+                      </span>
+                    </div>
+
+                    <span className="shrink-0 text-[11px] text-muted-foreground/60">
+                      {isMoving ? (
+                        <LoadingAnimation className="h-4 w-4 text-primary" />
+                      ) : isCurrentTarget ? (
+                        <span className="text-xs font-medium border border-secondary-foreground/20 bg-secondary text-secondary-foreground px-2 py-0.5 app-radius-md">
+                          current
+                        </span>
+                      ) : (
+                        <span className="text-[11px] text-muted-foreground/50">
+                          move
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { FaEllipsisVertical, FaRegTrashCan } from "react-icons/fa6";
+import { FileOutput } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { useMutation } from "convex/react";
 import { useQuery } from "@/cache/useQuery";
@@ -32,6 +33,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Label } from "../ui/label";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
+import MoveTableDialog from "./MoveTableDialog";
 interface TableSettingsProps {
   notesTableId: Id<"notesTables"> | any; // Strongly typed Id
   tableName: string | any;
@@ -58,6 +60,7 @@ export default function TableSettings({
   const [inputValue, setInputValue] = useState(tableName);
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false); // Alert Dialog State
+  const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const table = useQuery(api.notesTables.getTableById, { _id: notesTableId });
   const updateTable = useMutation(
@@ -185,6 +188,11 @@ export default function TableSettings({
       setIsAlertOpen(false); // Close Alert after deletion
     }
   };
+  const handleMoveDialogOpen = () => {
+    setOpen(false);
+    setIsMoveDialogOpen(true);
+  };
+
   const tooltip = useHoverTooltip(100);
   const createdAtText = formatTimestamp(table?.createdAt);
   const updatedAtText = formatTimestamp(table?.updatedAt);
@@ -229,6 +237,17 @@ export default function TableSettings({
             </DropdownMenuGroup>
             <DropdownMenuGroup>
               <Button
+                variant="SidebarMenuButton"
+                className="w-full h-8 px-2 text-sm"
+                onClick={handleMoveDialogOpen}
+                aria-label="move-table"
+              >
+                <FileOutput size={14} className="text-muted-foreground" />
+                Move Table
+              </Button>
+
+              <DropdownMenuSeparator />
+              <Button
                 variant="SidebarMenuButton_destructive"
                 className="w-full h-8 px-2 text-sm"
                 onClick={initiateDelete}
@@ -245,7 +264,7 @@ export default function TableSettings({
             </DropdownMenuGroup>
           </DropdownMenuContent>
           <TooltipContent side="bottom" alignOffset={1} align="end">
-            Rename , Delete
+            Rename, Move, Delete
           </TooltipContent>
         </Tooltip>
       </DropdownMenu>
@@ -279,6 +298,18 @@ export default function TableSettings({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {table && (
+        <MoveTableDialog
+          open={isMoveDialogOpen}
+          onOpenChange={setIsMoveDialogOpen}
+          table={{
+            _id: notesTableId,
+            name: table.name,
+            workingSpaceId: table.workingSpaceId,
+          }}
+        />
+      )}
     </>
   );
 }

--- a/convex/links.ts
+++ b/convex/links.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { linkMetadataValidator, linkPlatformValidator } from "./linkValidators";
 import { paginationOptsValidator } from "convex/server";
+import { ConvexError } from "convex/values";
 
 async function assertTableAccess(
   ctx: { db: any },
@@ -114,7 +115,7 @@ export const getLinkById = query({
 
     const link = await ctx.db.get(args._id);
     if (!link || link.userId !== userId) {
-      throw new Error("Link not found or not authorized");
+      throw new ConvexError("Link not found or not authorized");
     }
 
     return link;
@@ -126,7 +127,7 @@ export const getFavLinks = query({
   handler: async (ctx, { paginationOpts }) => {
     const userId = await getAuthUserId(ctx);
     if (!userId) {
-      throw new Error("Unauthenticated");
+      throw new ConvexError("Not authenticated");
     }
 
     return await ctx.db
@@ -146,12 +147,12 @@ export const updateLink = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
     if (!userId) {
-      throw new Error("Unauthenticated");
+      throw new ConvexError("Not authenticated");
     }
 
     const link = await ctx.db.get(args._id);
     if (!link || link.userId !== userId) {
-      throw new Error("Link not found or not authorized");
+      throw new ConvexError("Link not found or not authorized");
     }
 
     await ctx.db.patch(args._id, {
@@ -167,15 +168,68 @@ export const deleteLink = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
     if (!userId) {
-      throw new Error("Unauthenticated");
+      throw new ConvexError("Not authenticated");
     }
 
     const link = await ctx.db.get(args._id);
     if (!link || link.userId !== userId) {
-      throw new Error("Link not found or not authorized");
+      throw new ConvexError("Link not found or not authorized");
     }
 
     await ctx.db.delete(args._id);
     return args._id;
+  },
+});
+export const moveLink = mutation({
+  args: {
+    _id: v.id("links"),
+    targetWorkingSpaceId: v.id("workingSpaces"),
+    targetNotesTableId: v.id("notesTables"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new ConvexError("Not authenticated");
+    }
+
+    const { _id, targetWorkingSpaceId, targetNotesTableId } = args;
+
+    const link = await ctx.db.get(_id);
+    if (!link) {
+      throw new ConvexError("Link not found");
+    }
+
+    if (link.userId !== userId) {
+      throw new ConvexError("Not authorized to move this link");
+    }
+
+    const targetWorkspace = await ctx.db.get(targetWorkingSpaceId);
+    if (!targetWorkspace) {
+      throw new ConvexError("Target workspace not found");
+    }
+    if (targetWorkspace.userId !== userId) {
+      throw new ConvexError("Not authorized to use this workspace");
+    }
+
+    const targetTable = await ctx.db.get(targetNotesTableId);
+    if (!targetTable) {
+      throw new ConvexError("Target table not found");
+    }
+    if (targetTable.workingSpaceId !== targetWorkingSpaceId) {
+      throw new ConvexError("Target table does not belong to this workspace");
+    }
+
+    await ctx.db.patch(_id, {
+      workingSpaceId: targetWorkingSpaceId,
+      notesTableId: targetNotesTableId,
+      updatedAt: Date.now(),
+    });
+
+    return {
+      linkId: _id,
+      workingSpaceId: targetWorkingSpaceId,
+      notesTableId: targetNotesTableId,
+      title: link.title,
+    };
   },
 });

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -410,7 +410,69 @@ export const getFavNotes = query({
     };
   },
 });
+export const getWorkspaceTreeForMove = query({
+  args: {
+    searchQuery: v.optional(v.string()),
+  },
+  handler: async (ctx, { searchQuery }) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new ConvexError("Not authenticated");
+    }
 
+    const normalizedQuery = normalizeSearchText(searchQuery?.trim());
+    const isSearching = normalizedQuery.length > 0;
+
+    const workspaces = await ctx.db
+      .query("workingSpaces")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .order("desc")
+      .collect();
+
+    const targets = await Promise.all(
+      workspaces.map(async (workspace) => {
+        const allTables = await ctx.db
+          .query("notesTables")
+          .withIndex("by_workingSpaceId", (q) =>
+            q.eq("workingSpaceId", workspace._id),
+          )
+          .collect();
+
+        const sortedTables = allTables.sort(
+          (a, b) => b.updatedAt - a.updatedAt,
+        );
+
+        if (!isSearching) {
+          // No filtering here: every workspace and every table is a valid
+          // move destination, whether or not it has content yet.
+          return { ...workspace, tables: sortedTables };
+        }
+
+        const workspaceMatches = normalizeSearchText(workspace.name).includes(
+          normalizedQuery,
+        );
+
+        // Workspace name matched: keep all its tables so the user can
+        // still pick any of them, not just ones whose name also matched.
+        if (workspaceMatches) {
+          return { ...workspace, tables: sortedTables };
+        }
+
+        const matchingTables = sortedTables.filter((table) =>
+          normalizeSearchText(table.name).includes(normalizedQuery),
+        );
+
+        if (matchingTables.length > 0) {
+          return { ...workspace, tables: matchingTables };
+        }
+
+        return null;
+      }),
+    );
+
+    return targets.filter(Boolean) as NonNullable<(typeof targets)[number]>[];
+  },
+});
 export const getWorkspaceTree = query({
   args: {
     searchQuery: v.optional(v.string()),

--- a/convex/notesTables.ts
+++ b/convex/notesTables.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { generateSlug } from "../lib/generateSlug";
+import { ConvexError } from "convex/values";
 
 export const createTable = mutation({
   args: {
@@ -11,7 +12,7 @@ export const createTable = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
     if (!userId) {
-      throw new Error("Not authenticated");
+      throw new ConvexError("Not authenticated");
     }
 
     const { name, workingSpaceId } = args;
@@ -19,11 +20,13 @@ export const createTable = mutation({
     // Verify the user owns the workspace
     const workspace = await ctx.db.get(workingSpaceId);
     if (!workspace) {
-      throw new Error("Workspace not found");
+      throw new ConvexError("Workspace not found");
     }
 
     if (workspace.userId !== userId) {
-      throw new Error("Not authorized to create tables in this workspace");
+      throw new ConvexError(
+        "Not authorized to create tables in this workspace",
+      );
     }
 
     const generateSlugName = generateSlug(name);
@@ -131,23 +134,25 @@ export const updateTable = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
     if (!userId) {
-      throw new Error("Not authenticated");
+      throw new ConvexError("Not authenticated");
     }
 
     const { _id, name } = args;
     const table = await ctx.db.get(_id);
     if (!table) {
-      throw new Error("Table not found");
+      throw new ConvexError("Table not found");
     }
 
     // Verify the user owns the workspace that contains this table
     const workspace = await ctx.db.get(table.workingSpaceId);
     if (!workspace) {
-      throw new Error("Workspace not found");
+      throw new ConvexError("Workspace not found");
     }
 
     if (workspace.userId !== userId) {
-      throw new Error("Not authorized to update tables in this workspace");
+      throw new ConvexError(
+        "Not authorized to update tables in this workspace",
+      );
     }
 
     const generateSlugName = generateSlug(name ?? table.name ?? "Untitled");
@@ -199,11 +204,13 @@ export const deleteTable = mutation({
 
     const workspace = await ctx.db.get(table.workingSpaceId);
     if (!workspace) {
-      throw new Error("Workspace not found");
+      throw new ConvexError("Workspace not found");
     }
 
     if (workspace.userId !== userId) {
-      throw new Error("Not authorized to delete tables in this workspace");
+      throw new ConvexError(
+        "Not authorized to delete tables in this workspace",
+      );
     }
 
     const notesToDelete = await ctx.db
@@ -259,11 +266,11 @@ export const getTables = query({
     // Verify the user owns the workspace
     const workspace = await ctx.db.get(workingSpaceId);
     if (!workspace) {
-      throw new Error("Workspace not found");
+      throw new ConvexError("Workspace not found");
     }
 
     if (workspace.userId !== userId) {
-      throw new Error("Not authorized to view tables in this workspace");
+      throw new ConvexError("Not authorized to view tables in this workspace");
     }
 
     const tables = await ctx.db
@@ -284,23 +291,143 @@ export const getTableById = query({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
     if (!userId) {
-      throw new Error("Not authenticated");
+      throw new ConvexError("Not authenticated");
     }
 
     const table = await ctx.db.get(args._id);
     if (!table) {
-      throw new Error("Table not found");
+      throw new ConvexError("Table not found");
     }
 
     const workspace = await ctx.db.get(table.workingSpaceId);
     if (!workspace) {
-      throw new Error("Workspace not found");
+      throw new ConvexError("Workspace not found");
     }
 
     if (workspace.userId !== userId) {
-      throw new Error("Not authorized to view this table");
+      throw new ConvexError("Not authorized to view this table");
     }
 
     return table;
   },
 });
+export const getWorkspacesForMove = query({
+  args: {
+    searchQuery: v.optional(v.string()),
+  },
+  handler: async (ctx, { searchQuery }) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new ConvexError("Not authenticated");
+    }
+
+    const workspaces = await ctx.db
+      .query("workingSpaces")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .order("desc")
+      .collect();
+
+    const normalizedQuery = normalizeSearchText(searchQuery?.trim());
+    if (!normalizedQuery) {
+      return workspaces;
+    }
+
+    return workspaces.filter((workspace) =>
+      normalizeSearchText(workspace.name).includes(normalizedQuery),
+    );
+  },
+});
+
+export const moveTable = mutation({
+  args: {
+    _id: v.id("notesTables"),
+    targetWorkingSpaceId: v.id("workingSpaces"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new ConvexError("Not authenticated");
+    }
+
+    const { _id, targetWorkingSpaceId } = args;
+
+    const table = await ctx.db.get(_id);
+    if (!table) {
+      throw new ConvexError("Table not found");
+    }
+
+    const currentWorkspace = await ctx.db.get(table.workingSpaceId);
+    if (!currentWorkspace || currentWorkspace.userId !== userId) {
+      throw new ConvexError("Not authorized to move this table");
+    }
+
+    const targetWorkspace = await ctx.db.get(targetWorkingSpaceId);
+    if (!targetWorkspace) {
+      throw new ConvexError("Target workspace not found");
+    }
+    if (targetWorkspace.userId !== userId) {
+      throw new ConvexError("Not authorized to use this workspace");
+    }
+
+    if (table.workingSpaceId === targetWorkingSpaceId) {
+      // No-op move: already in the target workspace.
+      return {
+        tableId: _id,
+        workingSpaceId: targetWorkingSpaceId,
+        workingSpacesSlug: targetWorkspace.slug,
+      };
+    }
+
+    await ctx.db.patch(_id, {
+      workingSpaceId: targetWorkingSpaceId,
+      updatedAt: Date.now(),
+    });
+
+    const [notesInTable, pdfsInTable, linksInTable] = await Promise.all([
+      ctx.db
+        .query("notes")
+        .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
+        .collect(),
+      ctx.db
+        .query("pdfs")
+        .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
+        .collect(),
+      ctx.db
+        .query("links")
+        .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
+        .collect(),
+    ]);
+
+    await Promise.all([
+      ...notesInTable.map((note) =>
+        ctx.db.patch(note._id, {
+          workingSpaceId: targetWorkingSpaceId,
+          workingSpacesSlug: targetWorkspace.slug ?? note.workingSpacesSlug,
+          updatedAt: Date.now(),
+        }),
+      ),
+      ...pdfsInTable.map((pdf) =>
+        ctx.db.patch(pdf._id, {
+          workingSpaceId: targetWorkingSpaceId,
+          updatedAt: Date.now(),
+        }),
+      ),
+      ...linksInTable.map((link) =>
+        ctx.db.patch(link._id, {
+          workingSpaceId: targetWorkingSpaceId,
+          updatedAt: Date.now(),
+        }),
+      ),
+    ]);
+
+    return {
+      tableId: _id,
+      workingSpaceId: targetWorkingSpaceId,
+      workingSpacesSlug: targetWorkspace.slug,
+    };
+  },
+});
+
+function normalizeSearchText(value: string | undefined) {
+  return (value ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
+}


### PR DESCRIPTION
## what changed
<img width="545" height="525" alt="image" src="https://github.com/user-attachments/assets/ee11daf0-91fc-4f4b-b319-86fa2416aac0" />


* Added a **Move Link** action to the link settings menu.
* Added a **Move Table** action to the table settings menu.
* Added the backend mutations needed to move links and tables between workspaces.
* Moving a table also updates the workspace information for all notes, PDFs, and links inside that table so everything stays in sync.
* Added dedicated workspace/tree queries for move dialogs, including search support.
* Updated note and PDF move dialogs to use the new move-specific workspace tree query.
* Switched Convex authentication and authorization errors to `ConvexError` for more consistent error handling.
* Added validation on the backend to make sure users can only move their own links/tables and only use workspaces they have access to.

## why

Before this, links and tables didn't have a way to be moved after they were created. This makes moving content between workspaces much easier without having to recreate or manually reorganize everything.

The new move-specific queries also make the destination picker more useful by allowing it to show valid workspaces and tables even when they don't have any content yet, while still supporting search by workspace or table name.

Users can now reorganize their workspaces more easily by moving links and entire tables directly from their settings menus.

Moving a table also keeps all of its related content attached to the correct workspace, so notes, PDFs, and links don't get left behind with stale workspace information.

The backend also has stronger validation around these operations, so move actions can't be used to access or modify another user's workspaces or content.
