### PR TITLE
remove border radius on toggle title input

### DIFF
--- a/components/toggle-action-node.tsx
+++ b/components/toggle-action-node.tsx
@@ -320,7 +320,7 @@ function ToggleActionComponent({ node, updateAttributes }: NodeViewProps) {
               titleTooltip.hide();
             }}
             style={contrastStyle}
-            className="min-w-0 h-6 !p-0 !m-0 !border-0 focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 flex-1 bg-transparent text-sm font-medium text-foreground outline-none"
+            className="min-w-0 h-6 !p-0 !m-0 !border-0 focus-visible:ring-0 focus-visible:outline-none focus-visible:ring-offset-0 flex-1 bg-transparent text-sm font-medium text-foreground outline-none !rounded-none"
           />
         ) : (
           <Tooltip open={titleTooltip.open} disableHoverableContent>


### PR DESCRIPTION
before :
<img width="268" height="159" alt="image" src="https://github.com/user-attachments/assets/683553eb-85e3-448a-a29c-cd51c7778299" />

now : 
<img width="364" height="100" alt="image" src="https://github.com/user-attachments/assets/3dd4c6c4-d68c-486a-aa1d-3edaa940997c" />


added `!rounded-none` to the editable title input in the toggle action node.

it was picking up a slight radius that didn’t match the rest of the control. sits flush now.