### PR TITLE
clean up workspace menu ui

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -1385,7 +1385,7 @@ export function NotesDroppableContainer({
         </div>
 
         <div className="flex items-center gap-2 w-auto justify-end">
-          <div className="flex h-9 items-center border border-border app-radius-lg overflow-hidden">
+          <div className="flex h-9 items-center border border-border rounded-none overflow-hidden">
             {!isMobile && (
               <Button
                 variant="SidebarMenuButton"

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -249,7 +249,7 @@ export default function TableSettings({
               <DropdownMenuSeparator />
               <Button
                 variant="SidebarMenuButton_destructive"
-                className="w-full h-8 px-2 text-sm"
+                className="w-full h-8 px-2 text-sm text-foreground"
                 onClick={initiateDelete}
                 aria-label="delete-table"
               >

--- a/components/home-components/workingspace-new-dropdown-btn.tsx
+++ b/components/home-components/workingspace-new-dropdown-btn.tsx
@@ -454,16 +454,21 @@ export default function WorkingspaceNewDropdownBtn({
               <ChevronDown className="h-4 w-4" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-fit">
-            <DropdownMenuItem onClick={() => void handleSelectNote()}>
-              <FileText className="h-4 w-4 text-muted-foreground" />
-              New note
+          <DropdownMenuContent align="end" className="w-60">
+            <DropdownMenuItem
+              className="justify-between"
+              onClick={() => void handleSelectNote()}
+            >
+              <span className="flex items-center gap-2">
+                <FileText className="h-4 w-4 text-muted-foreground" />
+                New Note
+              </span>
               <span className="inline-flex gap-0.5">
                 <kbd className="pointer-events-none border border-border ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
-                  <span className="text-xs">Ctrl + Shift</span>
+                  <span className="text-[10px]">Ctrl + Shift</span>
                 </kbd>
                 <kbd className="pointer-events-none border border-border ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
-                  <span className="text-xs">O</span>
+                  <span className="text-[10px]">O</span>
                 </kbd>
               </span>
             </DropdownMenuItem>
@@ -471,15 +476,20 @@ export default function WorkingspaceNewDropdownBtn({
               <FileUp className="h-4 w-4 text-muted-foreground" />
               Upload PDF
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={handleSelectInsertLink}>
-              <Link2 className="h-4 w-4 text-muted-foreground" />
-              Insert Link
+            <DropdownMenuItem
+              className="justify-between"
+              onClick={handleSelectInsertLink}
+            >
+              <span className="flex items-center gap-2">
+                <Link2 className="h-4 w-4 text-muted-foreground" />
+                Insert Link
+              </span>
               <span className="inline-flex gap-0.5">
                 <kbd className="pointer-events-none border border-border ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
-                  <span className="text-xs">Shift</span>
+                  <span className="text-[10px]">Shift</span>
                 </kbd>
                 <kbd className="pointer-events-none border border-border ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md bg-card px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
-                  <span className="text-xs">L</span>
+                  <span className="text-[10px]">L</span>
                 </kbd>
               </span>
             </DropdownMenuItem>


### PR DESCRIPTION
## what changed

* Removed the rounded corners from the notes view control group to keep the controls more consistent with the surrounding UI.
* Fixed the table delete button text color so it uses the normal foreground color.
* Increased the workspace create dropdown width to give the menu items more room.
* Updated the **New Note** and **Insert Link** menu items to better align their labels and keyboard shortcuts.
* Reduced the keyboard shortcut text size so the shortcuts feel less prominent and fit better in the menu.
* Made the menu labels more consistent by changing `New note` to `New Note`.

These changes are mostly focused on cleaning up the workspace UI and making the dropdown feel more balanced.

The keyboard shortcuts were previously competing a bit with the menu labels, especially in the narrower dropdown. Giving the menu a fixed width and aligning the shortcuts to the right makes the actions easier to scan while keeping the shortcuts available.

The small styling adjustments also make the controls and destructive actions fit better with the rest of the interface.

The workspace creation menu has a cleaner layout, with actions on the left and their shortcuts consistently aligned on the right.

The updated sizing and spacing also make the dropdown easier to read and less cramped, while the smaller shortcut labels keep the focus on the actual actions.
