### PR TITLE
clean up link sidebar button

### DIFF
--- a/components/home-components/LinkSettingsSidebar.tsx
+++ b/components/home-components/LinkSettingsSidebar.tsx
@@ -83,7 +83,7 @@ export default function LinkSettingsSidebar({
             <Button
               onClick={handleFavoritePin}
               variant="SidebarMenuButton"
-              className="px-1.5 h-7 hover:bg-card !rounded-none"
+              className="px-1.5 h-7 hover:bg-card"
               aria-label="pin-link"
               {...pinTooltip.triggerProps}
             >


### PR DESCRIPTION
* Removed the forced `rounded-none` styling from the pin link button in the link settings sidebar.

The button was overriding the default sidebar button styling with square corners, which made it look inconsistent with the rest of the sidebar.
