### PR TITLE
improve search shortcuts and pdf viewer ui

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -1297,6 +1297,32 @@ export function NotesDroppableContainer({
   const [deletedItemIds, setDeletedItemIds] = useState<Set<string>>(new Set());
   const [contentFilter, setContentFilter] = useState<ContentFilter>("all");
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [isSearchFocused, setIsSearchFocused] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "/") return;
+
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      const isTyping =
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        target?.isContentEditable ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.altKey;
+
+      if (isTyping) return;
+
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   useEffect(() => {
     setDeletedItemIds(new Set());
@@ -1374,13 +1400,21 @@ export function NotesDroppableContainer({
           <div className="relative flex-1 min-w-0 md:max-w-md">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 mt-px text-foreground" />
             <Input
+              ref={searchInputRef as any}
               type="text"
               placeholder="Search notes and uploads..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-10 border-border h-9 mt-0.5"
+              onFocus={() => setIsSearchFocused(true)}
+              onBlur={() => setIsSearchFocused(false)}
+              className="pl-10 pr-9 border-border h-[37px] my-0 !rounded-none"
               aria-label="search-notes"
             />
+            {!isSearchFocused && !searchQuery && (
+              <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 mt-px inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1 font-mono text-[11px] text-muted-foreground">
+                /
+              </kbd>
+            )}
           </div>
         </div>
 

--- a/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
+++ b/app/home/[id]/pdf/[pdfId]/PdfViewerPageClient.tsx
@@ -572,11 +572,13 @@ function PdfViewerContent({
       }
     >
       <div className=" relative min-w-full min-h-full bg-transparent ">
-        <div className=" pointer-events-none absolute inset-x-0 top-1 z-20">
+        <div
+          className={` pointer-events-none absolute inset-x-0 ${isMobile ? "top-0" : "top-1"} z-20`}
+        >
           <div
             className={cn(
               "pointer-events-auto mx-auto flex w-fit flex-wrap md:flex-nowrap items-center justify-start gap-1 border border-border bg-card px-0.5 py-0.5",
-              !renderedInPane && "app-radius-lg",
+              !renderedInPane || (isMobile && "app-radius-lg"),
             )}
           >
             {(!open || isMobile) && (
@@ -585,7 +587,7 @@ function PdfViewerContent({
                 size="icon"
                 className={cn(
                   "h-8 w-8 border border-border",
-                  renderedInPane && "!rounded-none",
+                  renderedInPane || (isMobile && "!rounded-none"),
                 )}
                 aria-label="show-search-panel"
               >
@@ -728,7 +730,7 @@ function PdfViewerContent({
         ) : null}
 
         <div className=" absolute inset-y-0 right-0 z-10 flex h-screen w-full items-center justify-center border-b border-border bg-background">
-          <Pages className="scrollbar-gutter-stable [&::-webkit-scrollbar-track]:bg-transparent h-full min-h-0 w-full transition-all scroll-smooth [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border">
+          <Pages className="scrollbar-gutter-stable [&::-webkit-scrollbar-track]:bg-transparent h-full min-h-0 w-full transition-all scroll-smooth [&::-webkit-scrollbar]:h-[0.4rem] [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border">
             <Page>
               <CanvasLayer />
               <TextLayer />


### PR DESCRIPTION
## what changed
before : 
<img width="521" height="991" alt="image" src="https://github.com/user-attachments/assets/f170ebd6-6bd3-481b-a65c-fd2396fa55f7" />

after : 
<img width="540" height="984" alt="image" src="https://github.com/user-attachments/assets/3308fa1d-7751-434a-82c9-d7563fe99647" />


* Added `/` as a keyboard shortcut to quickly focus the workspace search input.
* Prevented the `/` shortcut from triggering while typing in inputs, textareas, editable content, or when using modifier keys.
* Added a small `/` keyboard hint inside the search input when it's empty and not focused.
* Updated the search input sizing and spacing to better fit the surrounding controls.
* Adjusted the PDF viewer toolbar positioning and rounded corners on mobile.
* Fixed the PDF viewer's search panel button styling so it behaves correctly in mobile and pane layouts.
* Added horizontal scrollbar sizing to the PDF pages container.

The workspace search was useful but required manually clicking the search field every time. Using `/` as a quick shortcut makes it much faster to jump into search, while the visible `/` hint makes the shortcut discoverable without getting in the way.

The PDF changes mainly clean up some layout differences between desktop, mobile, and pane views. The toolbar and controls now adapt better to the available space instead of using the same styling everywhere.

## now

Searching through notes and uploads is quicker and feels more like a keyboard-first workflow. You can simply press `/` from the workspace and start typing immediately, while normal typing and other shortcuts aren't interrupted.

The PDF viewer also has more consistent toolbar positioning and control styling across mobile and desktop, with better scrollbar behavior for horizontally scrollable pages.
