### PR TITLE
better link icons in search

### DIFF
--- a/components/home-components/SearchDialog.tsx
+++ b/components/home-components/SearchDialog.tsx
@@ -10,7 +10,7 @@ import {
   ChevronRight,
   Folder,
   FolderOpen,
-  Link2,
+  Globe,
 } from "lucide-react";
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
@@ -195,6 +195,42 @@ function PdfItem({
   );
 }
 
+function getSearchLinkFaviconUrl(url: string): string | null {
+  try {
+    const domain = new URL(url).hostname.replace(/^www\./, "");
+    return `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
+  } catch {
+    return null;
+  }
+}
+
+function SearchLinkFavicon({
+  url,
+  className,
+}: {
+  url: string;
+  className?: string;
+}) {
+  const [errored, setErrored] = useState(false);
+  const faviconUrl = url ? getSearchLinkFaviconUrl(url) : null;
+
+  if (!faviconUrl || errored) {
+    return <Globe className={cn("text-muted-foreground", className)} />;
+  }
+
+  return (
+    <img
+      src={faviconUrl}
+      alt=""
+      className={cn(
+        "object-contain grayscale contrast-125 saturate-0",
+        className,
+      )}
+      onError={() => setErrored(true)}
+    />
+  );
+}
+
 function LinkItem({ link, onClick, isSelected, query, indented = false }: any) {
   return (
     <div
@@ -205,7 +241,7 @@ function LinkItem({ link, onClick, isSelected, query, indented = false }: any) {
         isSelected ? "bg-border" : "hover:bg-border",
       )}
     >
-      <Link2 size={14} />
+      <SearchLinkFavicon url={link.url} className="h-3.5 w-3.5 shrink-0" />
       <div className="flex-1 overflow-hidden">
         <p className="text-sm text-foreground font-medium truncate transition-colors">
           <HighlightedText


### PR DESCRIPTION
## what changed
before : 
<img width="875" height="164" alt="image" src="https://github.com/user-attachments/assets/1abb5b6b-dfde-4186-88a9-318cdcb35437" />

after : 
<img width="890" height="167" alt="image" src="https://github.com/user-attachments/assets/9b66ff8b-c603-45f8-a5cc-eaaf6f97dce5" />


* Replaced the generic link icon in the search results with the website's favicon.
* Added a small helper to generate the favicon URL from the link domain.
* Added a fallback to the globe icon when the URL is invalid or the favicon fails to load.
* Kept favicons grayscale so they fit better with the existing search UI.

The search results were using the same generic link icon for every link, which made it harder to quickly recognize where a link comes from.

Using the website favicon gives each link a bit more visual context while keeping the search result layout simple.

## now

Links in search results are easier to recognize at a glance since they now show the site's favicon instead of the same icon for every result.

There’s also a safe fallback to the globe icon, so broken or invalid favicon URLs won't cause a broken image to appear in the search UI.
