### PR TITLE
better ui for pinned link hover state

### DIFF
--- a/components/home-components/AppSidebar.tsx
+++ b/components/home-components/AppSidebar.tsx
@@ -20,6 +20,7 @@ import {
   FolderPlus,
   SquarePen,
   PanelRightOpen,
+  ExternalLink,
 } from "lucide-react";
 import { TbSelector } from "react-icons/tb";
 import {
@@ -1214,10 +1215,17 @@ const PinnedLinkItem = memo(
                     rel="noopener noreferrer"
                     className="flex items-center gap-2 flex-grow min-w-0"
                   >
-                    <SidebarLinkFavicon
-                      url={link.url}
-                      className="h-4 w-4 flex-shrink-0"
-                    />
+                    {isHovered ? (
+                      <ExternalLink
+                        size="16"
+                        className="text-muted-foreground flex-shrink-0"
+                      />
+                    ) : (
+                      <SidebarLinkFavicon
+                        url={link.url}
+                        className="h-4 w-4 flex-shrink-0"
+                      />
+                    )}
                     <span className={textClassName}>
                       {formatWorkspaceName(displayTitle)}
                     </span>


### PR DESCRIPTION
## what changed
before : 
<img width="237" height="76" alt="image" src="https://github.com/user-attachments/assets/d120ac26-1f7a-494d-9916-9b026142b8a0" />

now : 
<img width="258" height="56" alt="image" src="https://github.com/user-attachments/assets/466627bb-d45b-4c11-87cf-f34885881210" />


* Replaced the link favicon with an external-link icon when hovering over a pinned link.
* Kept the favicon visible in the normal state.
* Used the muted external-link icon to make the hover state subtle and consistent with the sidebar.

The favicon is useful for identifying the link, but when hovering over it, it doesn't give much indication that the item can be opened.

Switching to the external-link icon on hover gives a clearer visual cue that clicking the pinned link will open the external page.

Pinned links are easier to understand and interact with. The favicon still provides quick visual identification when idle, while the hover state now clearly communicates the link's action without adding extra UI.
