### PR TITLE
improve client side content ordering

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -319,7 +319,7 @@ function useClientSideOrder<T extends { _id: string }>(
   storageKey: string,
   items: T[],
 ) {
-  const [orderIds, setOrderIds] = useState<string[]>([]);
+  const [sessionOrder, setSessionOrder] = useState<string[]>([]);
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [draggedSize, setDraggedSize] = useState<{
     width: number;
@@ -330,15 +330,26 @@ function useClientSideOrder<T extends { _id: string }>(
   useEffect(() => {
     try {
       const raw = localStorage.getItem(storageKey);
-      setOrderIds(raw ? (JSON.parse(raw) as string[]) : []);
+      setSessionOrder(raw ? (JSON.parse(raw) as string[]) : []);
     } catch {
-      setOrderIds([]);
+      setSessionOrder([]);
     }
   }, [storageKey]);
 
+  useEffect(() => {
+    setSessionOrder((prev) => {
+      const known = new Set(prev);
+      const newIds = items
+        .map((item) => item._id)
+        .filter((id) => !known.has(id));
+      if (newIds.length === 0) return prev;
+      return [...prev, ...newIds];
+    });
+  }, [items]);
+
   const persist = useCallback(
     (ids: string[]) => {
-      setOrderIds(ids);
+      setSessionOrder(ids);
       try {
         localStorage.setItem(storageKey, JSON.stringify(ids));
       } catch {
@@ -349,15 +360,14 @@ function useClientSideOrder<T extends { _id: string }>(
   );
 
   const orderedItems = useMemo(() => {
-    if (orderIds.length === 0) return items;
     const itemById = new Map(items.map((item) => [item._id, item]));
-    const known = orderIds
+    const known = sessionOrder
       .map((id) => itemById.get(id))
       .filter((item): item is T => Boolean(item));
     const knownIds = new Set(known.map((item) => item._id));
     const fresh = items.filter((item) => !knownIds.has(item._id));
     return [...known, ...fresh];
-  }, [items, orderIds]);
+  }, [items, sessionOrder]);
 
   const handleDragStart = useCallback(
     (id: string, rect?: { width: number; height: number }) => {
@@ -1332,6 +1342,7 @@ export function NotesDroppableContainer({
       ? cachedLinks
       : linkResults;
 
+  // Single combined pagination state driving one "Show More" button for
   // notes + pdfs + links together.
   const aggregateStatus:
     | "LoadingFirstPage"


### PR DESCRIPTION
## what changed

* Renamed the local ordering state from `orderIds` to `sessionOrder` to better describe how it's being used.
* Automatically adds newly loaded items to the end of the current session order.
* Keeps the existing saved order while new notes, PDFs, or links are loaded through pagination.
* Continues to persist manual drag-and-drop ordering to `localStorage`.
* Simplified the ordering logic so it can handle items being added after the initial load without resetting the existing order.

With paginated content, new items can arrive after the initial set has already been ordered. Without tracking those new IDs as they appear, the ordering state can become inconsistent as more content is loaded.

Now, whenever new items are received, their IDs are added to the current session order instead of being treated as completely new content by the ordering logic.

The workspace keeps a stable content order while loading more items. Existing items stay where the user expects them, and newly loaded items are added after the current session order rather than unexpectedly changing the existing layout.

