### PR TITLE
well new timeline card previews and hover animations

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -2436,6 +2436,57 @@ function CalendarGapMarker({
   );
 }
 
+function TimelineMiniThumbnail({ item }: { item: WorkspaceEntry }) {
+  const [imgLoaded, setImgLoaded] = useState(false);
+  const isLink = item.kind === "link";
+  const thumbnailUrl = isLink
+    ? (item as LinkItem).metadata?.thumbnailUrl
+    : undefined;
+  const isPending = isLink && (item as LinkItem).metadata === undefined;
+  const showSkeleton = isPending || (Boolean(thumbnailUrl) && !imgLoaded);
+
+  if (!isLink) {
+    return (
+      <div className="h-9 w-9 flex items-center justify-center flex-shrink-0 app-radius-md bg-muted">
+        <FileText className="h-4 w-4 text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-9 w-9 flex items-center justify-center flex-shrink-0">
+      {thumbnailUrl && (
+        <img
+          src={thumbnailUrl}
+          alt=""
+          draggable={false}
+          onLoad={() => setImgLoaded(true)}
+          onError={() => setImgLoaded(false)}
+          className={cn(
+            "h-full w-full object-cover app-radius-md select-none [-webkit-user-drag:none] transition-opacity duration-300",
+            imgLoaded ? "opacity-100" : "opacity-0",
+          )}
+        />
+      )}
+
+      {showSkeleton && (
+        <div className="absolute inset-0 app-radius-md bg-border/60 animate-pulse" />
+      )}
+
+      {!isPending && !thumbnailUrl && (
+        <div className="h-full w-full app-radius-md bg-muted flex items-center justify-center">
+          <Link2 className="h-4 w-4 text-muted-foreground" />
+        </div>
+      )}
+
+      <LinkFaviconBadge
+        url={(item as LinkItem).url}
+        className="absolute -bottom-1 -right-1 h-[14px] w-[14px]"
+      />
+    </div>
+  );
+}
+
 function TimelineMiniCard({
   item,
   workspaceId,
@@ -2464,17 +2515,13 @@ function TimelineMiniCard({
     createdDate.getFullYear() !== new Date().getFullYear();
 
   const cardClassName = cn(
-    "group flex items-start gap-2 border border-border bg-card hover:border-primary/50 hover:translate-x-[-1px] hover:translate-y-[-1px] hover:shadow-[2px_2px_0px] shadow-primary transition-all app-radius-md px-2.5 py-2",
+    "group flex items-center gap-2 border border-border bg-card hover:border-primary/20 hover:bg-muted/40 transition-colors app-radius-md px-2.5 py-2",
     inPopover ? "w-full" : "w-[168px]",
   );
 
   const cardContent = (
     <>
-      {isLink ? (
-        <Link2 className="h-3.5 w-3.5 text-primary mt-0.5 flex-shrink-0" />
-      ) : (
-        <FileText className="h-3.5 w-3.5 text-primary mt-0.5 flex-shrink-0" />
-      )}
+      <TimelineMiniThumbnail item={item} />
       <div className="min-w-0 flex-1">
         <p className="text-xs font-medium text-foreground line-clamp-2 leading-tight">
           {item.title || (isLink ? (item as LinkItem).url : "Untitled")}


### PR DESCRIPTION
## what changed

before : 
<img width="391" height="290" alt="image" src="https://github.com/user-attachments/assets/32da4142-6ed6-4c3e-8f84-1787ea279836" />

now : 

<img width="521" height="351" alt="image" src="https://github.com/user-attachments/assets/0c53485a-8da5-41d3-9489-a3e41db6f708" />


* Added thumbnail support to timeline mini cards for links.
* Link thumbnails now show a loading skeleton while the metadata or image is still loading.
* Added a smooth fade-in when the thumbnail finishes loading.
* Added the link favicon as a small badge on top of the thumbnail.
* Added proper fallback icons for links without thumbnails and regular notes/PDFs.
* Updated the timeline card styling with a simpler hover state and smoother transitions.
* Changed the cards from top-aligned to vertically centered content for a cleaner layout.

The timeline cards were previously using the same small generic icon for every item, which didn't give much visual information about what the item actually was.

Since links already have thumbnail metadata available, showing it in the timeline makes the cards easier to recognize without having to open them.

The updated hover styling also keeps the timeline feeling lighter and less visually busy.

##now

Timeline items are more recognizable at a glance, especially links with available thumbnails. The favicon badge also makes it easier to identify the source of a link.

Loading states are handled without the card jumping between different layouts, and links without thumbnails still have a clean fallback.

Overall, the timeline cards feel more polished while taking up roughly the same amount of space.
