### PR TITLE
add grouped link filters and improve link metadata

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -58,6 +58,16 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   AlertDialog,
@@ -142,7 +152,10 @@ type ContentFilter =
   | "youtube"
   | "x"
   | "instagram"
-  | "linkedin";
+  | "linkedin"
+  | "link";
+
+type FilterIconComponent = (props: { className?: string }) => any;
 
 const CONTENT_FILTER_OPTIONS: {
   value: ContentFilter;
@@ -155,14 +168,38 @@ const CONTENT_FILTER_OPTIONS: {
   { value: "x", label: "X" },
   { value: "instagram", label: "Instagram" },
   { value: "linkedin", label: "LinkedIn" },
+  { value: "link", label: "Link" },
 ];
+
+const GROUPABLE_LINK_FILTERS = new Set<ContentFilter>([
+  "youtube",
+  "x",
+  "instagram",
+  "linkedin",
+  "link",
+]);
+
+function isGenericLinkPlatform(
+  platform: LinkPlatform | string | undefined,
+): boolean {
+  if (!platform) return true;
+  const p = String(platform).toLowerCase();
+  return !(
+    p.includes("youtube") ||
+    p === "yt" ||
+    p === "x" ||
+    p.includes("twitter") ||
+    p.includes("instagram") ||
+    p === "ig" ||
+    p.includes("linkedin")
+  );
+}
 
 function matchesLinkPlatform(
   platform: LinkPlatform | string | undefined,
   filter: ContentFilter,
 ): boolean {
-  if (!platform) return false;
-  const p = String(platform).toLowerCase();
+  const p = String(platform ?? "").toLowerCase();
   switch (filter) {
     case "youtube":
       return p.includes("youtube") || p === "yt";
@@ -172,9 +209,98 @@ function matchesLinkPlatform(
       return p.includes("instagram") || p === "ig";
     case "linkedin":
       return p.includes("linkedin");
+    case "link":
+      return isGenericLinkPlatform(platform);
     default:
       return false;
   }
+}
+
+function getLinkGroupKey(link: LinkItem, filter: ContentFilter): string | null {
+  if (filter === "link") {
+    try {
+      return new URL(link.url).hostname.replace(/^www\./, "").toLowerCase();
+    } catch {
+      return null;
+    }
+  }
+  const handle = link.metadata?.authorHandle?.trim();
+  const name = link.metadata?.authorName?.trim();
+  return (handle || name || null)?.toLowerCase() ?? null;
+}
+
+// Human-readable label for a group key (see getLinkGroupKey).
+function getLinkGroupLabel(
+  link: LinkItem,
+  filter: ContentFilter,
+): string | null {
+  if (filter === "link") {
+    try {
+      return new URL(link.url).hostname.replace(/^www\./, "");
+    } catch {
+      return null;
+    }
+  }
+  return (
+    link.metadata?.authorName?.trim() ||
+    link.metadata?.authorHandle?.trim() ||
+    null
+  );
+}
+
+interface LinkFilterGroup {
+  key: string;
+  label: string;
+  handle?: string;
+  avatarUrl?: string;
+  sampleUrl?: string;
+  count: number;
+}
+
+// Normalizes a raw handle into "@handle" display form.
+function formatHandle(handle?: string | null): string | null {
+  const trimmed = handle?.trim();
+  if (!trimmed) return null;
+  return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
+}
+
+function GroupAvatar({
+  avatarUrl,
+  label,
+  className,
+}: {
+  avatarUrl?: string;
+  label: string;
+  className?: string;
+}) {
+  const [errored, setErrored] = useState(false);
+  const src = avatarUrl && !errored ? avatarUrl : null;
+
+  if (!src) {
+    return (
+      <div
+        className={cn(
+          "h-6 w-6 rounded-full bg-muted flex items-center justify-center text-[10px] font-medium text-muted-foreground shrink-0",
+          className,
+        )}
+      >
+        {label.charAt(0).toUpperCase()}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      key={src}
+      src={src}
+      alt=""
+      draggable={false}
+      referrerPolicy="no-referrer"
+      loading="lazy"
+      className={cn("h-6 w-6 rounded-full object-cover shrink-0", className)}
+      onError={() => setErrored(true)}
+    />
+  );
 }
 
 interface Note {
@@ -1400,6 +1526,7 @@ export function NotesDroppableContainer({
 
   const [deletedItemIds, setDeletedItemIds] = useState<Set<string>>(new Set());
   const [contentFilter, setContentFilter] = useState<ContentFilter>("all");
+  const [subFilterValue, setSubFilterValue] = useState<string | null>(null);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [isSearchFocused, setIsSearchFocused] = useState(false);
@@ -1431,7 +1558,65 @@ export function NotesDroppableContainer({
   useEffect(() => {
     setDeletedItemIds(new Set());
     setContentFilter("all");
+    setSubFilterValue(null);
   }, [tableId]);
+
+  const linkGroupsByFilter = useMemo(() => {
+    const map: Partial<Record<ContentFilter, LinkFilterGroup[]>> = {};
+
+    GROUPABLE_LINK_FILTERS.forEach((filter) => {
+      const matched = stableLinks.filter((link) =>
+        matchesLinkPlatform((link as LinkItem).platform, filter),
+      );
+
+      const counts = new Map<
+        string,
+        {
+          label: string;
+          handle?: string;
+          avatarUrl?: string;
+          sampleUrl: string;
+          count: number;
+        }
+      >();
+
+      matched.forEach((rawLink) => {
+        const link = rawLink as LinkItem;
+        const key = getLinkGroupKey(link, filter);
+        if (!key) return;
+        const label = getLinkGroupLabel(link, filter) ?? key;
+        const existing = counts.get(key);
+        if (existing) {
+          existing.count += 1;
+          if (!existing.avatarUrl && link.metadata?.authorAvatarUrl) {
+            existing.avatarUrl = link.metadata.authorAvatarUrl;
+          }
+          if (!existing.handle && link.metadata?.authorHandle) {
+            existing.handle = link.metadata.authorHandle;
+          }
+        } else {
+          counts.set(key, {
+            label,
+            handle: filter === "link" ? undefined : link.metadata?.authorHandle,
+            avatarUrl:
+              filter === "link" ? undefined : link.metadata?.authorAvatarUrl,
+            sampleUrl: link.url,
+            count: 1,
+          });
+        }
+      });
+
+      const groups = Array.from(counts.entries())
+        .map(([key, v]) => ({ key, ...v }))
+        .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+
+      if (groups.length > 1) {
+        map[filter] = groups;
+      }
+    });
+
+    return map;
+  }, [stableLinks]);
 
   const filteredItems = useMemo(() => {
     const noteItems = stableResults.map(
@@ -1454,6 +1639,14 @@ export function NotesDroppableContainer({
         if (item.kind !== "link") return false;
         return matchesLinkPlatform(item.platform, contentFilter);
       });
+
+      if (subFilterValue && GROUPABLE_LINK_FILTERS.has(contentFilter)) {
+        items = items.filter(
+          (item) =>
+            item.kind === "link" &&
+            getLinkGroupKey(item as LinkItem, contentFilter) === subFilterValue,
+        );
+      }
     }
 
     if (!searchQuery.trim()) return items;
@@ -1470,6 +1663,7 @@ export function NotesDroppableContainer({
     });
   }, [
     contentFilter,
+    subFilterValue,
     deletedItemIds,
     stableLinks,
     stablePdfs,
@@ -1502,7 +1696,7 @@ export function NotesDroppableContainer({
     filteredItems,
   );
   const displayItems =
-    searchQuery.trim() || contentFilter !== "all"
+    searchQuery.trim() || contentFilter !== "all" || subFilterValue
       ? filteredItems
       : orderedItems;
 
@@ -1582,8 +1776,8 @@ export function NotesDroppableContainer({
             workingSpacesSlug={workspaceSlug}
             CNBP_notesTableId={tableId}
           />
-          <Popover open={isFilterOpen} onOpenChange={setIsFilterOpen}>
-            <PopoverTrigger asChild>
+          <DropdownMenu open={isFilterOpen} onOpenChange={setIsFilterOpen}>
+            <DropdownMenuTrigger asChild>
               <Button
                 type="button"
                 variant="outline"
@@ -1595,41 +1789,128 @@ export function NotesDroppableContainer({
                 aria-label="filter-content"
               >
                 <Filter className="h-3.5 w-3.5" />
-                <span className="hidden sm:inline">
-                  {CONTENT_FILTER_OPTIONS.find((o) => o.value === contentFilter)
-                    ?.label ?? "All"}
+                <span className="hidden sm:inline truncate max-w-[9rem] items-center gap-1.5 ">
+                  <span className="truncate">
+                    {CONTENT_FILTER_OPTIONS.find(
+                      (o) => o.value === contentFilter,
+                    )?.label ?? "All"}
+                    {subFilterValue
+                      ? ` · ${
+                          linkGroupsByFilter[contentFilter]?.find(
+                            (g) => g.key === subFilterValue,
+                          )?.label ?? subFilterValue
+                        }`
+                      : ""}
+                  </span>
                 </span>
               </Button>
-            </PopoverTrigger>
-            <PopoverContent
-              align="end"
-              className="w-32 p-1 border-border bg-card"
-            >
-              <div className="flex flex-col gap-0.5">
-                {CONTENT_FILTER_OPTIONS.map((option) => (
-                  <Button
-                    key={option.value}
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className={cn(
-                      "justify-start h-8 px-2 font-normal",
-                      contentFilter === option.value && "bg-muted",
-                    )}
-                    onClick={() => {
-                      setContentFilter(option.value);
-                      setIsFilterOpen(false);
-                    }}
-                  >
-                    {option.label}
-                    {contentFilter === option.value ? (
-                      <Check className="ml-auto h-3.5 w-3.5" />
-                    ) : null}
-                  </Button>
-                ))}
-              </div>
-            </PopoverContent>
-          </Popover>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              {CONTENT_FILTER_OPTIONS.map((option) => {
+                const groups = linkGroupsByFilter[option.value];
+                const hasGroups = Boolean(groups && groups.length > 0);
+                const isActiveCategory = contentFilter === option.value;
+
+                if (!hasGroups) {
+                  return (
+                    <DropdownMenuItem
+                      key={option.value}
+                      className={cn(
+                        "gap-2",
+                        isActiveCategory && !subFilterValue && "bg-muted",
+                      )}
+                      onSelect={() => {
+                        setContentFilter(option.value);
+                        setSubFilterValue(null);
+                      }}
+                    >
+                      <span className="truncate">{option.label}</span>
+                      {isActiveCategory && !subFilterValue ? (
+                        <Check className="ml-auto h-3.5 w-3.5 shrink-0" />
+                      ) : null}
+                    </DropdownMenuItem>
+                  );
+                }
+
+                return (
+                  <DropdownMenuSub key={option.value}>
+                    <DropdownMenuSubTrigger
+                      className={cn(
+                        "gap-2",
+                        isActiveCategory && !subFilterValue && "bg-muted",
+                      )}
+                    >
+                      <span className="truncate">{option.label}</span>
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="w-64 max-h-80 overflow-y-auto [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-border">
+                      <DropdownMenuItem
+                        className={cn(
+                          "gap-2",
+                          isActiveCategory && !subFilterValue && "bg-muted",
+                        )}
+                        onSelect={() => {
+                          setContentFilter(option.value);
+                          setSubFilterValue(null);
+                        }}
+                      >
+                        <span className="truncate">All {option.label}</span>
+                        {isActiveCategory && !subFilterValue ? (
+                          <Check className="ml-auto h-3.5 w-3.5 shrink-0" />
+                        ) : null}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      {groups!.map((group) => {
+                        const isActiveGroup =
+                          isActiveCategory && subFilterValue === group.key;
+                        return (
+                          <DropdownMenuItem
+                            key={group.key}
+                            className={cn(
+                              "gap-2 py-1.5",
+                              isActiveGroup && "bg-muted",
+                            )}
+                            onSelect={() => {
+                              setContentFilter(option.value);
+                              setSubFilterValue(group.key);
+                            }}
+                          >
+                            {option.value === "link" ? (
+                              <LinkFaviconBadge
+                                url={group.sampleUrl ?? ""}
+                                className="h-6 w-6 shrink-0"
+                              />
+                            ) : (
+                              <GroupAvatar
+                                avatarUrl={group.avatarUrl}
+                                label={group.label}
+                              />
+                            )}
+                            <div className="flex flex-col items-start min-w-0 flex-1">
+                              <span className="text-xs font-medium truncate w-full text-left">
+                                {group.label}
+                              </span>
+                              {option.value !== "link" &&
+                              formatHandle(group.handle) ? (
+                                <span className="text-[10px] text-muted-foreground truncate w-full text-left">
+                                  {formatHandle(group.handle)}
+                                </span>
+                              ) : null}
+                            </div>
+                            <span className="text-[10px] text-muted-foreground shrink-0 pl-1">
+                              {group.count}
+                            </span>
+                            {isActiveGroup ? (
+                              <Check className="h-3 w-3 shrink-0" />
+                            ) : null}
+                          </DropdownMenuItem>
+                        );
+                      })}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                );
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
           <TableSettings
             notesTableId={tableId}
             tableName={tables?.find((t) => t._id === tableId)?.name}
@@ -1645,12 +1926,18 @@ export function NotesDroppableContainer({
           searchQuery={
             searchQuery.trim()
               ? searchQuery
-              : (CONTENT_FILTER_OPTIONS.find((o) => o.value === contentFilter)
-                  ?.label ?? "filter")
+              : (subFilterValue &&
+                  linkGroupsByFilter[contentFilter]?.find(
+                    (g) => g.key === subFilterValue,
+                  )?.label) ||
+                (CONTENT_FILTER_OPTIONS.find((o) => o.value === contentFilter)
+                  ?.label ??
+                  "filter")
           }
           onClearSearch={() => {
             setSearchQuery("");
             setContentFilter("all");
+            setSubFilterValue(null);
           }}
         />
       ) : filteredItems.length === 0 ? (

--- a/convex/Linkmetadata.ts
+++ b/convex/Linkmetadata.ts
@@ -1,5 +1,5 @@
 import { action } from "./_generated/server";
-import { api } from "./_generated/api";
+import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import { linkPlatformValidator, linkMetadataFields } from "./linkValidators";
 import {
@@ -18,6 +18,7 @@ type FetchedLinkMetadata = {
     thumbnailUrl?: string;
     authorName?: string;
     authorHandle?: string;
+    authorAvatarUrl?: string;
     publishedAt?: number;
     duration?: string;
     embedVideoId?: string;
@@ -124,11 +125,132 @@ async function fetchOgTags(url: string) {
   };
 }
 
+// Preferred path: YouTube's official Data API v3. Requires a
+// YOUTUBE_API_KEY environment variable (free tier — set it in the Convex
+// dashboard under Settings > Environment Variables, or `npx convex env set
+// YOUTUBE_API_KEY <key>`). This is reliable because it's a normal signed
+// API call, not scraping — Google does not consent-wall or CAPTCHA
+// server-to-server API traffic the way it does plain HTML requests coming
+// from a datacenter IP (which is exactly what makes the HTML-scrape
+// fallback below unreliable in production).
+async function fetchYoutubeChannelInfoViaApi(
+  videoId: string,
+): Promise<{ avatarUrl?: string; handle?: string; channelName?: string }> {
+  const apiKey = process.env.YOUTUBE_API_KEY;
+  if (!apiKey) return {};
+
+  try {
+    const videoRes = await fetchWithTimeout(
+      `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${encodeURIComponent(
+        videoId,
+      )}&key=${apiKey}`,
+    );
+    if (!videoRes.ok) {
+      console.error(
+        `YouTube Data API videos.list failed: ${videoRes.status} ${await videoRes.text().catch(() => "")}`,
+      );
+      return {};
+    }
+    const videoData = (await videoRes.json()) as {
+      items?: { snippet?: { channelId?: string } }[];
+    };
+    const channelId = videoData.items?.[0]?.snippet?.channelId;
+    if (!channelId) return {};
+
+    const channelRes = await fetchWithTimeout(
+      `https://www.googleapis.com/youtube/v3/channels?part=snippet&id=${encodeURIComponent(
+        channelId,
+      )}&key=${apiKey}`,
+    );
+    if (!channelRes.ok) {
+      console.error(
+        `YouTube Data API channels.list failed: ${channelRes.status} ${await channelRes.text().catch(() => "")}`,
+      );
+      return {};
+    }
+    const channelData = (await channelRes.json()) as {
+      items?: {
+        snippet?: {
+          title?: string;
+          customUrl?: string;
+          thumbnails?: {
+            default?: { url?: string };
+            medium?: { url?: string };
+          };
+        };
+      }[];
+    };
+    const snippet = channelData.items?.[0]?.snippet;
+    if (!snippet) return {};
+
+    const rawHandle = snippet.customUrl;
+    return {
+      avatarUrl:
+        snippet.thumbnails?.medium?.url ?? snippet.thumbnails?.default?.url,
+      handle: rawHandle
+        ? rawHandle.startsWith("@")
+          ? rawHandle
+          : `@${rawHandle}`
+        : undefined,
+      channelName: snippet.title,
+    };
+  } catch (error) {
+    console.error("YouTube Data API channel lookup failed:", error);
+    return {};
+  }
+}
+
+// Fallback for when YOUTUBE_API_KEY isn't set: scrape the channel page's
+// <meta> tags / canonical link the same way `fetchOgTags` does for other
+// platforms. Less reliable than the Data API above — Google frequently
+// serves a consent/CAPTCHA page instead of the real HTML to non-browser
+// traffic from server IPs, so this may silently return nothing.
+async function fetchYoutubeChannelExtras(
+  channelUrl: string,
+): Promise<{ avatarUrl?: string; handle?: string }> {
+  try {
+    const response = await fetchWithTimeout(channelUrl, {
+      headers: {
+        // Bypasses the EU cookie-consent interstitial that would otherwise
+        // replace the real channel page with a consent screen.
+        Cookie: "CONSENT=YES+1",
+      },
+    });
+    if (!response.ok) return {};
+
+    const rawHtml = await response.text();
+    const html = rawHtml.slice(0, MAX_HTML_LENGTH);
+
+    const avatarUrl =
+      extractMeta(html, "og:image") ?? extractMeta(html, "twitter:image");
+
+    let handle: string | undefined;
+    const canonicalMatch = html.match(
+      /<link[^>]+rel=["']canonical["'][^>]*href=["']([^"']+)["']/i,
+    );
+    if (canonicalMatch?.[1]) {
+      try {
+        const canonicalPath = new URL(canonicalMatch[1]).pathname;
+        const segment = canonicalPath.split("/").filter(Boolean).pop();
+        if (segment?.startsWith("@")) handle = segment;
+      } catch {
+        // Malformed canonical URL — just skip the handle.
+      }
+    }
+
+    return { avatarUrl, handle };
+  } catch (error) {
+    console.error("YouTube channel page fetch failed:", error);
+    return {};
+  }
+}
+
 async function fetchYoutubeMetadata(url: string): Promise<FetchedLinkMetadata> {
   const videoId = extractYoutubeVideoId(url) ?? undefined;
 
   let title: string | undefined;
   let authorName: string | undefined;
+  let authorUrl: string | undefined;
   let thumbnailUrl: string | undefined = videoId
     ? youtubeThumbnailUrl(videoId)
     : undefined;
@@ -144,14 +266,34 @@ async function fetchYoutubeMetadata(url: string): Promise<FetchedLinkMetadata> {
       const data = (await response.json()) as {
         title?: string;
         author_name?: string;
+        author_url?: string;
         thumbnail_url?: string;
       };
       title = data.title;
       authorName = data.author_name;
+      authorUrl = data.author_url;
       if (data.thumbnail_url) thumbnailUrl = data.thumbnail_url;
     }
   } catch (error) {
     console.error("YouTube oEmbed failed:", error);
+  }
+
+  let authorHandle: string | undefined;
+  let authorAvatarUrl: string | undefined;
+
+  if (videoId) {
+    const apiInfo = await fetchYoutubeChannelInfoViaApi(videoId);
+    authorAvatarUrl = apiInfo.avatarUrl;
+    authorHandle = apiInfo.handle;
+    if (!authorName && apiInfo.channelName) authorName = apiInfo.channelName;
+  }
+
+  // Only fall back to scraping for whatever the API didn't cover (e.g. no
+  // API key configured, or the video lookup failed for some reason).
+  if ((!authorAvatarUrl || !authorHandle) && authorUrl) {
+    const extras = await fetchYoutubeChannelExtras(authorUrl);
+    authorAvatarUrl = authorAvatarUrl ?? extras.avatarUrl;
+    authorHandle = authorHandle ?? extras.handle;
   }
 
   if (!videoId) {
@@ -160,6 +302,8 @@ async function fetchYoutubeMetadata(url: string): Promise<FetchedLinkMetadata> {
       metadata: {
         thumbnailUrl,
         authorName,
+        authorHandle,
+        authorAvatarUrl,
         siteName: "YouTube",
       },
     };
@@ -169,6 +313,8 @@ async function fetchYoutubeMetadata(url: string): Promise<FetchedLinkMetadata> {
     metadata: {
       thumbnailUrl,
       authorName,
+      authorHandle,
+      authorAvatarUrl,
       publishedAt,
       duration,
       siteName: "YouTube",
@@ -181,6 +327,20 @@ async function fetchXMetadata(url: string): Promise<FetchedLinkMetadata> {
   let authorName: string | undefined;
   let authorHandle: string | undefined;
   let thumbnailUrl: string | undefined;
+  let authorAvatarUrl: string | undefined;
+
+  // A profile link (x.com/username) has exactly one path segment; a tweet
+  // permalink (x.com/username/status/123) has more. og:image only reflects
+  // the account's own picture for the former — for a tweet it's the
+  // attached media/card image, which isn't a safe stand-in for an avatar.
+  const isProfileUrl = (() => {
+    try {
+      const path = new URL(url).pathname.replace(/^\/|\/$/g, "");
+      return Boolean(path) && !path.includes("/");
+    } catch {
+      return false;
+    }
+  })();
 
   try {
     const oembedUrl = `https://publish.twitter.com/oembed?url=${encodeURIComponent(
@@ -203,6 +363,7 @@ async function fetchXMetadata(url: string): Promise<FetchedLinkMetadata> {
   try {
     const og = await fetchOgTags(url);
     thumbnailUrl = og.image;
+    if (isProfileUrl) authorAvatarUrl = og.image;
     if (!authorName && og.author) authorName = og.author.replace(/^@/, "");
   } catch (error) {
     console.error("X OG failed:", error);
@@ -212,6 +373,7 @@ async function fetchXMetadata(url: string): Promise<FetchedLinkMetadata> {
     title: authorName ? `${authorName} on X` : undefined,
     metadata: {
       thumbnailUrl,
+      authorAvatarUrl,
       authorName,
       authorHandle,
       siteName: "X",
@@ -351,5 +513,70 @@ export const fetchLinkMetadata = action({
       console.error("fetchLinkMetadata failed:", error);
       return { metadata: {} };
     }
+  },
+});
+
+// One-time backfill for YouTube links saved before channel avatar/handle
+// lookup existed. Re-fetches each one via fetchYoutubeMetadata (which now
+// prefers the YouTube Data API when YOUTUBE_API_KEY is set) and patches in
+// whatever is missing. Safe to re-run — it only touches links that are
+// still missing an avatar or handle, and skips a link entirely if nothing
+// new was found for it.
+export const backfillYoutubeChannelInfo = action({
+  args: {},
+  returns: v.object({
+    scanned: v.number(),
+    updated: v.number(),
+    usingApiKey: v.boolean(),
+  }),
+  handler: async (
+    ctx,
+  ): Promise<{ scanned: number; updated: number; usingApiKey: boolean }> => {
+    const usingApiKey = Boolean(process.env.YOUTUBE_API_KEY);
+    if (!usingApiKey) {
+      console.warn(
+        "YOUTUBE_API_KEY is not set — falling back to HTML scraping, " +
+          "which YouTube frequently blocks from server IPs. Results may " +
+          "come back mostly empty. Set YOUTUBE_API_KEY in the Convex " +
+          "dashboard (Settings > Environment Variables) for reliable results.",
+      );
+    }
+
+    let cursor: string | null = null;
+    let scanned = 0;
+    let updated = 0;
+
+    while (true) {
+      const page: any = await ctx.runQuery(
+        internal.links.internalGetYoutubeLinksMissingChannelInfo,
+        { paginationOpts: { numItems: 25, cursor } },
+      );
+
+      for (const link of page.page) {
+        scanned += 1;
+        try {
+          const result = await fetchYoutubeMetadata(link.url);
+          const { authorHandle, authorAvatarUrl } = result.metadata;
+          if (authorHandle || authorAvatarUrl) {
+            await ctx.runMutation(internal.links.internalUpdateLinkMetadata, {
+              _id: link._id,
+              metadata: {
+                authorHandle: authorHandle ?? link.metadata?.authorHandle,
+                authorAvatarUrl:
+                  authorAvatarUrl ?? link.metadata?.authorAvatarUrl,
+              },
+            });
+            updated += 1;
+          }
+        } catch (error) {
+          console.error(`Backfill failed for link ${link._id}:`, error);
+        }
+      }
+
+      if (page.isDone) break;
+      cursor = page.continueCursor;
+    }
+
+    return { scanned, updated, usingApiKey };
   },
 });

--- a/convex/links.ts
+++ b/convex/links.ts
@@ -1,4 +1,9 @@
-import { mutation, query } from "./_generated/server";
+import {
+  mutation,
+  query,
+  internalMutation,
+  internalQuery,
+} from "./_generated/server";
 import { v } from "convex/values";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { linkMetadataValidator, linkPlatformValidator } from "./linkValidators";
@@ -181,6 +186,55 @@ export const deleteLink = mutation({
     return args._id;
   },
 });
+// Internal — used by the one-time backfillYoutubeChannelInfo admin action,
+// not exposed to the client. Runs without a user session (the dashboard's
+// "Run action" / a CLI-triggered run has no signed-in user attached), and
+// covers links for every user since it's a maintenance task, not a
+// per-user request.
+export const internalUpdateLinkMetadata = internalMutation({
+  args: {
+    _id: v.id("links"),
+    title: v.optional(v.string()),
+    metadata: linkMetadataValidator,
+  },
+  handler: async (ctx, args) => {
+    const link = await ctx.db.get(args._id);
+    if (!link) return;
+
+    await ctx.db.patch(args._id, {
+      title: args.title ?? link.title,
+      metadata: {
+        ...link.metadata,
+        ...args.metadata,
+      },
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+// Internal — same rationale as internalUpdateLinkMetadata above. Scans
+// across all users' YouTube links (not scoped to a single userId) for
+// links still missing a channel avatar/handle.
+export const internalGetYoutubeLinksMissingChannelInfo = internalQuery({
+  args: {
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("links")
+      .filter((q) => q.eq(q.field("platform"), "youtube"))
+      .paginate(args.paginationOpts);
+
+    return {
+      ...page,
+      page: page.page.filter(
+        (link) =>
+          !link.metadata?.authorAvatarUrl || !link.metadata?.authorHandle,
+      ),
+    };
+  },
+});
+
 export const moveLink = mutation({
   args: {
     _id: v.id("links"),


### PR DESCRIPTION
## what changed
<img width="513" height="309" alt="image" src="https://github.com/user-attachments/assets/d61929d4-8bb6-449a-bcf1-31ba20096447" />
<img width="494" height="164" alt="image" src="https://github.com/user-attachments/assets/421e4e12-6ad9-4f5b-9c4e-468d3cc3be4d" />


* added a new generic `Link` content filter for links that aren't YouTube, X, Instagram, or LinkedIn.
* changed the content filter from a simple popover into a dropdown with nested submenus.
* grouped links by platform, creator, or domain so large collections are easier to filter through.
* added link counts and avatars/favicons to the grouped filter options.
* added support for filtering YouTube, X, Instagram, and LinkedIn links by their author/creator.
* added domain-based grouping for generic links.
* added YouTube channel avatar and handle metadata fetching using the YouTube Data API, with HTML scraping as a fallback.
* added X profile avatar metadata when the link is a profile rather than a post.
* added a one-time backfill action to update older YouTube links that are missing channel avatars or handles.
* added internal Convex queries and mutations to safely support the metadata backfill.

## why

The old filter worked fine for a small number of links, but it became less useful as a workspace collected more content. Choosing "YouTube" or "X", for example, still meant going through every matching link instead of being able to narrow it down to a specific creator.

This change makes the filter more useful for larger collections by allowing links to be grouped and filtered at a more specific level. For generic links, grouping by domain also makes it much easier to find links from a particular website.

The metadata changes are mainly there to make those groups more useful visually. YouTube links can now provide the channel name, handle, and avatar, while generic links use their domain and favicon.

The YouTube Data API is preferred over scraping because server-side requests to YouTube can be blocked by consent or CAPTCHA pages. The existing scraping approach is kept as a fallback when the API key isn't available.

## now

The content filter is now much more useful when a workspace contains a lot of links. You can go from a broad filter like "YouTube" to a specific channel, or from "Link" to a specific domain, without having to search through every result manually.

The grouped options also show useful context like avatars, handles, favicons, and link counts, making it easier to understand what you're filtering before selecting it.

Older YouTube links are also covered through the backfill action, so existing data can benefit from the new channel metadata instead of only links created after this change.
