### PR TITLE
better twitter profile metadata and channel backfills

### DIFF
--- a/convex/Linkmetadata.ts
+++ b/convex/Linkmetadata.ts
@@ -339,20 +339,24 @@ async function fetchYoutubeMetadata(url: string): Promise<FetchedLinkMetadata> {
   };
 }
 
+async function fetchXProfileAvatar(
+  handle: string,
+): Promise<string | undefined> {
+  try {
+    const profileUrl = `https://x.com/${encodeURIComponent(handle)}`;
+    const og = await fetchOgTags(profileUrl);
+    return og.image;
+  } catch (error) {
+    console.error("X profile avatar fetch failed:", error);
+    return undefined;
+  }
+}
+
 async function fetchXMetadata(url: string): Promise<FetchedLinkMetadata> {
   let authorName: string | undefined;
   let authorHandle: string | undefined;
   let thumbnailUrl: string | undefined;
   let authorAvatarUrl: string | undefined;
-
-  const isProfileUrl = (() => {
-    try {
-      const path = new URL(url).pathname.replace(/^\/|\/$/g, "");
-      return Boolean(path) && !path.includes("/");
-    } catch {
-      return false;
-    }
-  })();
 
   try {
     const oembedUrl = `https://publish.twitter.com/oembed?url=${encodeURIComponent(
@@ -375,11 +379,21 @@ async function fetchXMetadata(url: string): Promise<FetchedLinkMetadata> {
   try {
     const og = await fetchOgTags(url);
     thumbnailUrl = og.image;
-    if (isProfileUrl) authorAvatarUrl = og.image;
     if (!authorName && og.author) authorName = og.author.replace(/^@/, "");
   } catch (error) {
     console.error("X OG failed:", error);
   }
+
+  if (authorHandle) {
+    authorAvatarUrl = await fetchXProfileAvatar(authorHandle);
+  }
+
+  console.log("[x-metadata] result", {
+    url,
+    authorHandle,
+    authorName,
+    authorAvatarUrl,
+  });
 
   return {
     title: authorName ? `${authorName} on X` : undefined,
@@ -528,12 +542,52 @@ export const fetchLinkMetadata = action({
   },
 });
 
-// One-time backfill for YouTube links saved before channel avatar/handle
-// lookup existed. Re-fetches each one via fetchYoutubeMetadata (which now
-// prefers the YouTube Data API when YOUTUBE_API_KEY is set) and patches in
-// whatever is missing. Safe to re-run — it only touches links that are
-// still missing an avatar or handle, and skips a link entirely if nothing
-// new was found for it.
+async function runChannelInfoBackfill(
+  ctx: { runQuery: any; runMutation: any },
+  platform: "youtube" | "x" | "instagram" | "linkedin",
+  fetcher: (url: string) => Promise<FetchedLinkMetadata>,
+): Promise<{ scanned: number; updated: number }> {
+  let cursor: string | null = null;
+  let scanned = 0;
+  let updated = 0;
+
+  while (true) {
+    const page: any = await ctx.runQuery(
+      internal.links.internalGetLinksMissingChannelInfo,
+      { platform, paginationOpts: { numItems: 25, cursor } },
+    );
+
+    for (const link of page.page) {
+      scanned += 1;
+      try {
+        const result = await fetcher(link.url);
+        const { authorHandle, authorAvatarUrl } = result.metadata;
+        if (authorHandle || authorAvatarUrl) {
+          await ctx.runMutation(internal.links.internalUpdateLinkMetadata, {
+            _id: link._id,
+            metadata: {
+              authorHandle: authorHandle ?? link.metadata?.authorHandle,
+              authorAvatarUrl:
+                authorAvatarUrl ?? link.metadata?.authorAvatarUrl,
+            },
+          });
+          updated += 1;
+        }
+      } catch (error) {
+        console.error(
+          `Backfill failed for ${platform} link ${link._id}:`,
+          error,
+        );
+      }
+    }
+
+    if (page.isDone) break;
+    cursor = page.continueCursor;
+  }
+
+  return { scanned, updated };
+}
+
 export const backfillYoutubeChannelInfo = action({
   args: {},
   returns: v.object({
@@ -554,41 +608,20 @@ export const backfillYoutubeChannelInfo = action({
       );
     }
 
-    let cursor: string | null = null;
-    let scanned = 0;
-    let updated = 0;
-
-    while (true) {
-      const page: any = await ctx.runQuery(
-        internal.links.internalGetYoutubeLinksMissingChannelInfo,
-        { paginationOpts: { numItems: 25, cursor } },
-      );
-
-      for (const link of page.page) {
-        scanned += 1;
-        try {
-          const result = await fetchYoutubeMetadata(link.url);
-          const { authorHandle, authorAvatarUrl } = result.metadata;
-          if (authorHandle || authorAvatarUrl) {
-            await ctx.runMutation(internal.links.internalUpdateLinkMetadata, {
-              _id: link._id,
-              metadata: {
-                authorHandle: authorHandle ?? link.metadata?.authorHandle,
-                authorAvatarUrl:
-                  authorAvatarUrl ?? link.metadata?.authorAvatarUrl,
-              },
-            });
-            updated += 1;
-          }
-        } catch (error) {
-          console.error(`Backfill failed for link ${link._id}:`, error);
-        }
-      }
-
-      if (page.isDone) break;
-      cursor = page.continueCursor;
-    }
+    const { scanned, updated } = await runChannelInfoBackfill(
+      ctx,
+      "youtube",
+      fetchYoutubeMetadata,
+    );
 
     return { scanned, updated, usingApiKey };
+  },
+});
+
+export const backfillXChannelInfo = action({
+  args: {},
+  returns: v.object({ scanned: v.number(), updated: v.number() }),
+  handler: async (ctx): Promise<{ scanned: number; updated: number }> => {
+    return await runChannelInfoBackfill(ctx, "x", fetchXMetadata);
   },
 });

--- a/convex/links.ts
+++ b/convex/links.ts
@@ -186,11 +186,7 @@ export const deleteLink = mutation({
     return args._id;
   },
 });
-// Internal — used by the one-time backfillYoutubeChannelInfo admin action,
-// not exposed to the client. Runs without a user session (the dashboard's
-// "Run action" / a CLI-triggered run has no signed-in user attached), and
-// covers links for every user since it's a maintenance task, not a
-// per-user request.
+
 export const internalUpdateLinkMetadata = internalMutation({
   args: {
     _id: v.id("links"),
@@ -212,17 +208,15 @@ export const internalUpdateLinkMetadata = internalMutation({
   },
 });
 
-// Internal — same rationale as internalUpdateLinkMetadata above. Scans
-// across all users' YouTube links (not scoped to a single userId) for
-// links still missing a channel avatar/handle.
-export const internalGetYoutubeLinksMissingChannelInfo = internalQuery({
+export const internalGetLinksMissingChannelInfo = internalQuery({
   args: {
+    platform: linkPlatformValidator,
     paginationOpts: paginationOptsValidator,
   },
   handler: async (ctx, args) => {
     const page = await ctx.db
       .query("links")
-      .filter((q) => q.eq(q.field("platform"), "youtube"))
+      .filter((q) => q.eq(q.field("platform"), args.platform))
       .paginate(args.paginationOpts);
 
     return {


### PR DESCRIPTION
## what changed

* added a dedicated X profile avatar lookup that fetches the profile page using the author's handle.
* changed X avatar handling so posts no longer use the post's OG image as the author's avatar.
* added a reusable `runChannelInfoBackfill` helper for processing missing channel metadata across different platforms.
* added a new `backfillXChannelInfo` action to backfill missing X handles and avatars for existing links.
* updated the internal Convex query to accept a platform, so the same backfill flow can be used for YouTube, X, and other supported platforms.
* kept the existing YouTube backfill behavior while moving the shared logic into the reusable helper.
* added logging for the final X metadata result to make avatar/handle issues easier to debug.


The previous X implementation could use the link's OG image as the author's avatar when the URL was a profile, but that doesn't work reliably for posts since the OG image can represent the post content instead of the account.

Now that we already have the author's handle from the metadata, we can use it to fetch the actual X profile and get the profile avatar directly. This gives us a more reliable avatar regardless of whether the saved link is a profile or a post.

The backfill logic was also becoming specific to YouTube, even though the same process is useful for other platforms. Moving it into a shared helper makes it easier to backfill metadata for additional platforms without duplicating the pagination, fetching, and update logic.