### PR TITLE
add copy link action for link settings dropdown

### DIFF
--- a/components/home-components/LinkSettings.tsx
+++ b/components/home-components/LinkSettings.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { useMutation } from "convex/react";
-import { ExternalLink, FileOutput, Pin } from "lucide-react";
+import { Check, Copy, ExternalLink, FileOutput, Pin } from "lucide-react";
 import { FaEllipsis, FaEllipsisVertical, FaRegTrashCan } from "react-icons/fa6";
 import type { Id } from "@/convex/_generated/dataModel";
 import { api } from "@/convex/_generated/api";
@@ -83,6 +83,7 @@ export default function LinkSettings({
   const [open, setOpen] = useState(false);
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
   const tooltip = useHoverTooltip(100);
 
   const updateLink = useMutation(api.links.updateLink);
@@ -96,6 +97,16 @@ export default function LinkSettings({
       favorite: !favorite,
     });
   }, [favorite, linkId, updateLink]);
+
+  const handleCopyLink = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(linkUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (error) {
+      console.error("Failed to copy link:", error);
+    }
+  }, [linkUrl]);
 
   const handleDelete = useCallback(async () => {
     if (onDelete) onDelete(linkId);
@@ -159,7 +170,7 @@ export default function LinkSettings({
             align={tooltipContentAlign}
             className="text-xs px-1.5 py-1"
           >
-            Pin, Open, Move, Delete
+            Pin, Open, Copy, Move, Delete
           </TooltipContent>
         </Tooltip>
 
@@ -190,6 +201,20 @@ export default function LinkSettings({
                 <ExternalLink size={14} className="text-muted-foreground" />
                 Open Link
               </a>
+            </Button>
+
+            <Button
+              variant="SidebarMenuButton"
+              className="w-full h-8 px-2 text-sm"
+              onClick={() => void handleCopyLink()}
+              aria-label="copy-link"
+            >
+              {copied ? (
+                <Check size={14} className="text-muted-foreground" />
+              ) : (
+                <Copy size={14} className="text-muted-foreground" />
+              )}
+              {copied ? "Copied!" : "Copy Link"}
             </Button>
 
             <Button


### PR DESCRIPTION
### what changed
<img width="214" height="247" alt="image" src="https://github.com/user-attachments/assets/5f3cb29c-3e22-402a-a774-93f3d98eadbb" />


* added a **Copy Link** action to the link settings menu
* uses the browser clipboard API to copy the link URL
* shows a `Copied!` state for a short time after copying
* switches the icon from copy to check when the link is copied
* updated the tooltip to include the new Copy action
* added basic error handling if copying fails

Previously, users had to open the link or manually select the URL to copy it. This makes copying the link directly from the settings menu much quicker.

* faster way to copy links
* clear visual feedback when the link is copied
* keeps the existing link settings flow simple and consistent
