### PR TITLE
better UXUI workSpace page scrolling topFade for table controls

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -1702,7 +1702,7 @@ export function NotesDroppableContainer({
 
   return (
     <div className="grid grid-cols-1 gap-6 w-full max-w-full">
-      <div className="flex flex-wrap gap-y-2 gap-x-4 items-start sm:items-center justify-between">
+      <div className="flex flex-wrap gap-y-2 gap-x-4 items-start sm:items-center justify-between sticky -top-5 z-30">
         <div className="flex items-center gap-3 flex-1 min-w-0">
           <div className="relative flex-1 min-w-0 md:max-w-md">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 mt-px text-foreground" />
@@ -1714,11 +1714,11 @@ export function NotesDroppableContainer({
               onChange={(e) => setSearchQuery(e.target.value)}
               onFocus={() => setIsSearchFocused(true)}
               onBlur={() => setIsSearchFocused(false)}
-              className="pl-10 pr-9 border-border h-[37px] my-0 !rounded-none"
+              className="pl-10 pr-9 border-border h-[37px] my-0 !rounded-none bg-background"
               aria-label="search-notes"
             />
             {!isSearchFocused && !searchQuery && (
-              <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 mt-px inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1 font-mono text-[11px] text-muted-foreground">
+              <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1 font-mono text-[11px] text-muted-foreground">
                 /
               </kbd>
             )}
@@ -1732,7 +1732,7 @@ export function NotesDroppableContainer({
                 variant="SidebarMenuButton"
                 size="sm"
                 className={cn(
-                  "!rounded-none hover:bg-muted",
+                  "!rounded-none bg-background hover:bg-muted",
                   viewMode === "grid" && "bg-muted",
                 )}
                 onClick={() => setViewMode("grid")}
@@ -1746,7 +1746,7 @@ export function NotesDroppableContainer({
               variant="SidebarMenuButton"
               size="sm"
               className={cn(
-                "!rounded-none hover:bg-muted",
+                "!rounded-none bg-background hover:bg-muted",
                 !isMobile && "border border-l-border border-r-border",
                 viewMode === "list" && "bg-muted",
               )}
@@ -1760,7 +1760,7 @@ export function NotesDroppableContainer({
               variant="SidebarMenuButton"
               size="sm"
               className={cn(
-                "!rounded-none hover:bg-muted",
+                "!rounded-none bg-background hover:bg-muted",
                 viewMode === "calendar" && "bg-muted",
               )}
               onClick={() => setViewMode("calendar")}

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -73,6 +73,12 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
 
   const showTopFade = scrollTop > 0;
 
+  // Only on notevo.me/home/[id] — grow the fade once the user scrolls past 180px
+  const isNoteDetailRoute = /^\/home\/[^/]+\/?$/.test(pathname);
+  const isPastFadeGrowThreshold = scrollTop > 180;
+  const fadeHeight =
+    isNoteDetailRoute && isPastFadeGrowThreshold ? "16rem" : "6rem";
+
   return (
     <div className="flex h-screen w-full bg-muted overflow-hidden">
       <AppSidebar />
@@ -125,10 +131,13 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
           }`}
         >
           <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: showTopFade ? 1 : 0 }}
-            transition={showTopFade ? fadeTransition.show : fadeTransition.hide}
-            className="rounded-tl-lg absolute top-0 left-0 w-full h-[4rem] bg-gradient-to-b from-background from-0% via-background/65 via-45% to-100% to-transparent z-20 pointer-events-none -mb-16"
+            initial={{ opacity: 0, height: "6rem" }}
+            animate={{ opacity: showTopFade ? 1 : 0, height: fadeHeight }}
+            transition={{
+              opacity: showTopFade ? fadeTransition.show : fadeTransition.hide,
+              height: { ease: "easeInOut", duration: 0.2 },
+            }}
+            className="rounded-tl-lg absolute top-0 left-0 w-full bg-gradient-to-b from-background from-0% via-background/65 via-45% to-100% to-transparent z-20 pointer-events-none -mb-16"
             aria-hidden
           />
           {children}

--- a/components/home-components/TableSettings.tsx
+++ b/components/home-components/TableSettings.tsx
@@ -68,9 +68,6 @@ export default function TableSettings({
   ).withOptimisticUpdate((local, args) => {
     const { _id, name } = args;
 
-    // Try to find the table in cached queries to get workingSpaceId
-    // This is a best-effort optimization - server will sync correctly regardless
-    // We search through common workspace queries
     const workspaces = local.getQuery(api.workingSpaces.getRecentWorkingSpaces);
     if (workspaces && Array.isArray(workspaces)) {
       for (const ws of workspaces) {
@@ -209,8 +206,8 @@ export default function TableSettings({
           <DropdownMenuTrigger asChild>
             <TooltipTrigger asChild>
               <Button
-                variant="Trigger"
-                className="pl-0.5 pr-0 h-9 mb-0.5 opacity-80"
+                variant="outline"
+                className="h-9 px-0.5  !rounded-none bg-background"
                 {...tooltip.triggerProps}
                 aria-label="table-options"
               >


### PR DESCRIPTION
## changes

<img width="1533" height="524" alt="image" src="https://github.com/user-attachments/assets/933b23d6-2526-4cab-99e2-a24a428259eb" />


* Made the notes search and view controls **sticky** so they stay visible while scrolling through a workspace.
* Added a solid background to the search input and view mode buttons so they don't become transparent or overlap awkwardly with the content underneath.
* Updated the `/home/[id]` top fade to grow from `6rem` to `16rem` after scrolling past `180px`.
* Added a smooth height transition to the fade so the change feels less abrupt while scrolling.
* Cleaned up the `TableSettings` optimistic update by removing the unnecessary comments around workspace lookup.
* Updated the table options button to use the `outline` variant with a background and adjusted spacing to better match the surrounding controls.

The main goal here is to make the note workspace easier to use when scrolling. Keeping the search and view controls visible means you don't have to scroll all the way back up just to search or switch between grid, list, and calendar views.

The larger fade on the note detail pages also gives the sticky controls some visual separation from the content while scrolling, making the transition feel cleaner.

The table options button was also adjusted to fit better with the updated UI and have a more consistent appearance with the other controls.

## better now

Overall, the workspace controls are easier to access while scrolling, the sticky header has better visual separation from the content, and the table controls feel more consistent with the rest of the UI.
