### PR TITLE
clean up button and tab control styling

### DIFF
--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -960,7 +960,7 @@ function SliderTabsList({
           onClick={() => scroll("left")}
           aria-label="scroll-tabs-left"
           className={cn(
-            "absolute left-1 top-1/2 -translate-y-1/2 z-10 h-8 app-radius-md w-7 shadow-sm transition-all duration-200 !rounded-sm",
+            "absolute left-1 top-1/2 -translate-y-1/2 z-10 h-8 app-radius-md w-7 shadow-sm transition-all duration-200 !rounded-none",
             canScrollLeft
               ? "opacity-100 pointer-events-auto"
               : "opacity-0 pointer-events-none",
@@ -975,7 +975,7 @@ function SliderTabsList({
           onClick={() => scroll("right")}
           aria-label="scroll-tabs-right"
           className={cn(
-            "absolute right-1 top-1/2 -translate-y-1/2 z-10 h-8 app-radius-md w-7 shadow-sm transition-all duration-200 !rounded-sm",
+            "absolute right-1 top-1/2 -translate-y-1/2 z-10 h-8 app-radius-md w-7 shadow-sm transition-all duration-200 !rounded-none",
             canScrollRight
               ? "opacity-100 pointer-events-auto"
               : "opacity-0 pointer-events-none",

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -15,7 +15,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-border/80 text-muted-foreground bg-background hover:bg-muted hover:border-border",
+          "border border-border text-muted-foreground bg-background hover:bg-muted",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: " hover:bg-border hover:text-foreground",


### PR DESCRIPTION
## changes
<img width="142" height="71" alt="image" src="https://github.com/user-attachments/assets/9e97fd05-9ec8-4035-b00e-e29f9131d0f8" />


* Removed the rounded corners from the left and right tab scroll buttons so they match the surrounding tab layout better.
* Updated the `outline` button variant to use the regular border color instead of the slightly transparent border.
* Removed the extra border change on hover from the `outline` variant so the hover state stays more consistent.


These changes are mainly focused on making the controls feel more consistent with the current UI. The tab scroll buttons looked slightly out of place with their rounded corners, especially around the tab container, so they're now completely square.

The `outline` button styling was also simplified by using the standard border and keeping the hover state focused on the background instead of changing the border as well.