### PR TITLE
better looking width and layout for faq and about sections

### DIFF
--- a/components/landingPage-components/MoreAboutMe.tsx
+++ b/components/landingPage-components/MoreAboutMe.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 export default function MoreAboutMe() {
   return (
     <section id="about" className="py-12 sm:py-16 md:py-20 Desktop:py-24">
-      <MaxWContainer className=" max-w-[1200px]">
+      <MaxWContainer className=" !max-w-[1300px]">
         <div className="relative pt-10">
           <div className="absolute inset-x-0 bottom-0 top-4 app-radius-sm bg-primary" />
           <div className="absolute inset-x-0 bottom-0 top-2 app-radius-sm bg-primary/90" />

--- a/components/landingPage-components/SectionHeading.tsx
+++ b/components/landingPage-components/SectionHeading.tsx
@@ -2,12 +2,15 @@
 interface SectionHeadingProps {
   SectionTitle: string;
   SectionSubTitle: string;
+  className?: string;
 }
 import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
 
 export default function SectionHeading({
   SectionTitle,
   SectionSubTitle,
+  className,
 }: SectionHeadingProps) {
   return (
     <motion.div
@@ -15,14 +18,14 @@ export default function SectionHeading({
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.8 }}
-      className="text-center mb-16"
+      className={cn("text-center mb-16", className)}
     >
       <h2 className="text-4xl md:text-6xl font-bold tracking-tight mb-4">
         <span className="bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent">
           {SectionTitle}
         </span>
       </h2>
-      <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+      <p className="text-lg text-muted-foreground max-w-[29rem] mx-auto">
         {SectionSubTitle}
       </p>
     </motion.div>

--- a/components/landingPage-components/faq.tsx
+++ b/components/landingPage-components/faq.tsx
@@ -13,20 +13,22 @@ export default function FAQ() {
       id="faq"
       className="relative pt-12 sm:pt-16 md:pt-20 Desktop:pt-24 "
     >
-      <MaxWContainer>
-        <SectionHeading
-          SectionTitle="Frequently Asked Questions"
-          SectionSubTitle="if your interested"
-        />
+      <MaxWContainer className="flex justify-between items-start !max-w-[1300px] ">
+        <div className="sticky top-24 max-w-lg">
+          <SectionHeading
+            SectionTitle="Frequently Asked Questions"
+            SectionSubTitle="if your interested in learning more about Notevo, here are some common QaA that may help you."
+          />
+        </div>
 
         <Accordion
           type="single"
           collapsible
           defaultValue="shipping"
-          className="max-w-2xl mx-auto min-h-[400px]"
+          className="max-w-2xl  min-h-[500px] flex-1"
         >
           {AccordionData.map((item, index) => (
-            <AccordionItem key={index} value={item.itmevalue}>
+            <AccordionItem key={index} value={item.itmevalue} className="mb-4">
               <AccordionTrigger className="animated-highlight-container text-2xl font-medium">
                 {" "}
                 <span className="animated-highlight">{item.trigger}</span>{" "}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -12,11 +12,6 @@ import {
 } from "lucide-react";
 
 export const NavLinks = [
-  // {
-  //   Name: "Home",
-  //   path: "/",
-  //   clicked: true,
-  // },
   {
     Name: "Features",
     path: "/#features",
@@ -64,8 +59,14 @@ export const AccordionData = [
     content:
       "I want to create a product that is truly for the users,  Plus, it just feels good to share your work with the world and see how others can build on it.",
   },
+  {
+    id: "3",
+    itmevalue: "ownership",
+    trigger: "Can I change my email or transfer ownership?",
+    content:
+      "no unfortunately, you cannot change your email or transfer ownership of your account. BUT we're wokring on that ",
+  },
 ] as const;
-
 export const HowToStartSteps = [
   {
     id: "1",


### PR DESCRIPTION
## changes
before: 
<img width="1511" height="842" alt="image" src="https://github.com/user-attachments/assets/0581e15c-46d7-43c5-884d-a5b7166bc70d" />

now : 
<img width="1302" height="840" alt="image" src="https://github.com/user-attachments/assets/1d419954-3510-46a4-bb16-128e1214b683" />


* Increased the max width of the About Me and FAQ sections to `1300px` so the content has more room on larger screens.
* Added support for passing a custom `className` to `SectionHeading` for more flexible layouts.
* Adjusted the FAQ section into a two-column layout with the heading staying sticky while scrolling through the questions.
* Increased the FAQ accordion height and added spacing between each question.
* Updated the FAQ subtitle with a more useful description.
* Added a new FAQ item explaining email changes and account ownership transfer.
* Cleaned up the unused commented-out Home navigation link from `NavLinks`.

The landing page had a lot of unused horizontal space, especially on larger screens, and the FAQ heading didn't stay visible while going through the questions.

The new layout gives the FAQ section a clearer structure and keeps the section heading available while scrolling. The reusable `className` on `SectionHeading` also makes it easier to adjust the heading depending on where it's used.

## better now

* Better use of space on larger screens.
* FAQ section is easier to scan and navigate.
* The FAQ heading stays visible while reading through the questions.
* More spacing between FAQ items makes the section feel less cramped.
* `SectionHeading` is more reusable and flexible.
* Added an FAQ covering account email and ownership changes.
