### PR TITLE
make faq responsive and improve heading

### DIFF
--- a/components/landingPage-components/SectionHeading.tsx
+++ b/components/landingPage-components/SectionHeading.tsx
@@ -25,7 +25,7 @@ export default function SectionHeading({
           {SectionTitle}
         </span>
       </h2>
-      <p className="text-lg text-muted-foreground max-w-[29rem] mx-auto">
+      <p className=" text-sm md:text-lg text-muted-foreground max-w-[29rem] mx-auto">
         {SectionSubTitle}
       </p>
     </motion.div>

--- a/components/landingPage-components/faq.tsx
+++ b/components/landingPage-components/faq.tsx
@@ -13,11 +13,11 @@ export default function FAQ() {
       id="faq"
       className="relative pt-12 sm:pt-16 md:pt-20 Desktop:pt-24 "
     >
-      <MaxWContainer className="flex justify-between items-start !max-w-[1300px] ">
-        <div className="sticky top-24 max-w-lg">
+      <MaxWContainer className="md:flex justify-between items-start !max-w-[1300px] ">
+        <div className="md:sticky top-24 md:max-w-lg">
           <SectionHeading
             SectionTitle="Frequently Asked Questions"
-            SectionSubTitle="if your interested in learning more about Notevo, here are some common QaA that may help you."
+            SectionSubTitle="if your interested in learning more about Notevo. "
           />
         </div>
 
@@ -25,7 +25,7 @@ export default function FAQ() {
           type="single"
           collapsible
           defaultValue="shipping"
-          className="max-w-2xl  min-h-[500px] flex-1"
+          className="max-w-2xl mx-auto md:mx-0 min-h-[500px] flex-1"
         >
           {AccordionData.map((item, index) => (
             <AccordionItem key={index} value={item.itmevalue} className="mb-4">

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -62,7 +62,7 @@ export const AccordionData = [
   {
     id: "3",
     itmevalue: "ownership",
-    trigger: "Can I change my email or transfer ownership?",
+    trigger: "Can I change my email?",
     content:
       "no unfortunately, you cannot change your email or transfer ownership of your account. BUT we're wokring on that ",
   },


### PR DESCRIPTION
## changes

* Made the FAQ two-column layout only apply on medium screens and up.
* Made the FAQ heading sticky only on medium screens and up.
* Centered the FAQ accordion on smaller screens and aligned it normally on desktop.
* Reduced the section subtitle size on mobile while keeping the larger size on desktop.
* Simplified the FAQ subtitle copy.
* Updated the email FAQ question to focus specifically on changing the account email.

The previous FAQ layout was mainly optimized for desktop and could feel cramped or awkward on smaller screens.

These changes make the section behave better across different screen sizes while keeping the sticky two-column layout where it actually makes sense.