### PR TITLE
tldraw drawing whiteboard canvas

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,179 @@
+@import "tldraw/tldraw.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Custom Whiteboard Canvas App Theme Overrides */
+.whiteboard-canvas {
+  --tl-color-background: hsl(var(--background));
+  --tl-color-panel: hsl(var(--card));
+  --tl-color-panel-contrast: hsl(var(--popover));
+  --tl-color-low: hsl(var(--muted));
+  --tl-color-low-border: hsl(var(--border));
+  --tl-color-divider: hsl(var(--border));
+  --tl-color-text: hsl(var(--card-foreground));
+  --tl-color-text-0: hsl(var(--card-foreground));
+  --tl-color-text-1: hsl(var(--card-foreground));
+  --tl-color-text-3: hsl(var(--muted-foreground));
+  --tl-color-selected: hsl(var(--primary));
+  --tl-color-selected-contrast: hsl(var(--primary-foreground));
+  --tl-color-muted-1: hsl(var(--accent));
+  --tl-color-muted-2: hsl(var(--muted));
+
+  --tl-radius-0: 0;
+  --tl-radius-1: 0;
+  --tl-radius-2: 0;
+  --tl-radius-3: 0;
+  --tl-radius-4: 0;
+}
+
+
+.whiteboard-canvas .tlui-style-panel .tlui-toolbar {
+  background-color: transparent !important;
+  border: none !important;
+  border-bottom: 1px solid hsl(var(--border)) !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+.whiteboard-canvas .tlui-style-panel__section:last-child .tlui-toolbar:last-child {
+  border-bottom: none !important;
+}
+
+/* Hide watermark, production tracking & attribution links */
+.whiteboard-canvas .tl-watermark_SEE-LICENSE,
+.whiteboard-canvas [data-testid*="tl-watermark"],
+.whiteboard-canvas .tl-watermark,
+.whiteboard-canvas .tlui-watermark,
+.whiteboard-canvas a[href*="tldraw.dev"] {
+  display: none !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+  visibility: hidden !important;
+}
+
+/* Whiteboard Panels, Toolbars & Menus background, border, & rounded styling */
+.whiteboard-canvas .tlui-toolbar,
+.whiteboard-canvas .tlui-menu-zone,
+.whiteboard-canvas .tlui-navigation-zone,
+.whiteboard-canvas .tlui-style-panel,
+.whiteboard-canvas .tlui-popover__content,
+.whiteboard-canvas .tlui-menu {
+  background-color: hsl(var(--card)) !important;
+  color: hsl(var(--card-foreground)) !important;
+  border: 1px solid hsl(var(--border)) !important;
+  border-radius: 0 !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
+}
+
+/* No .whiteboard-canvas scope — tooltips render outside it via a portal */
+.tlui-tooltip {
+  background-color: hsl(var(--muted)) !important;
+  color: hsl(var(--muted-foreground)) !important;
+  border: 1px solid hsl(var(--border)) !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+.tlui-tooltip svg,
+.tlui-tooltip [data-radix-popper-arrow] {
+  display: none !important;
+}
+
+.whiteboard-canvas .tlui-minimap {
+  background-color: hsl(var(--background)) !important;
+}
+
+.whiteboard-canvas .tlui-navigation-panel::before {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+.whiteboard-canvas .tlui-navigation-panel .tlui-toolbar {
+  background-color: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+/* Menu zone placement in bottom-right corner */
+.whiteboard-canvas .tlui-menu-zone {
+  position: absolute;
+  inset: auto 0.75rem calc(0.75rem + env(safe-area-inset-bottom)) auto;
+  z-index: var(--tl-layer-panels);
+}
+
+
+/* Base button styling inside whiteboard UI */
+.whiteboard-canvas .tlui-button {
+  border-radius: 0 !important;
+  transition: background-color 0.15s ease, color 0.15s ease !important;
+}
+
+/* Hover state for buttons & menu items */
+.whiteboard-canvas .tlui-button:hover:not(:disabled):not([data-disabled="true"]),
+.whiteboard-canvas .tlui-button[data-state="hover"] {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+/* Active / Selected tool buttons — cover every state attribute tldraw may use */
+.whiteboard-canvas .tlui-button[data-state="selected"],
+.whiteboard-canvas .tlui-button[aria-pressed="true"],
+.whiteboard-canvas .tlui-button[data-selected="true"],
+.whiteboard-canvas .tlui-button[data-isactive="true"],
+.whiteboard-canvas .tlui-button__tool[data-state="selected"] {
+  background-color: hsl(var(--primary)) !important;
+  color: hsl(var(--primary-foreground)) !important;
+  border-radius: 0 !important;
+}
+
+.whiteboard-canvas .tlui-button::after,
+.whiteboard-canvas .tlui-toolbar-toggle-group-item::after {
+  background: transparent !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
+}
+
+.whiteboard-canvas .tlui-button__tool[aria-pressed="true"]::after,
+.whiteboard-canvas .tlui-button__tool[data-isactive="true"]::after,
+.whiteboard-canvas .tlui-button__tool[data-state="selected"]::after {
+  background-color: hsl(var(--primary)) !important;
+  border-radius: 0 !important;
+}
+
+.whiteboard-canvas .tlui-button[data-state="selected"] svg,
+.whiteboard-canvas .tlui-button[aria-pressed="true"] svg,
+.whiteboard-canvas .tlui-button[data-selected="true"] svg,
+.whiteboard-canvas .tlui-button[data-isactive="true"] svg {
+  color: hsl(var(--primary-foreground)) !important;
+  fill: currentColor;
+}
+
+/* Opacity slider */
+.whiteboard-canvas .tlui-slider__track {
+  background-color: hsl(var(--card)) !important;
+}
+
+.whiteboard-canvas .tlui-slider__range {
+  background-color: hsl(var(--primary)) !important;
+}
+
+.whiteboard-canvas .tlui-slider__thumb {
+  background-color: hsl(var(--background)) !important;
+  border: 2px solid hsl(var(--primary)) !important;
+  border-radius: 50% !important;
+}
+
+.whiteboard-canvas .tlui-slider__thumb:focus-visible {
+  outline: 2px solid hsl(var(--ring)) !important;
+  outline-offset: 2px;
+}
+
+.whiteboard-canvas .tlui-slider__container {
+  background-color: hsl(var(--card)) !important;
+  padding: 0.2rem 0.5rem !important;
+}
 
 *:focus,
 *:focus-visible {

--- a/app/home/[id]/WorkingSpacePageClient.tsx
+++ b/app/home/[id]/WorkingSpacePageClient.tsx
@@ -10,6 +10,8 @@ import {
   ChevronRight,
   ChevronDown,
   Link2,
+  PanelTop,
+  Trash2,
   X,
   Filter,
 } from "lucide-react";
@@ -142,6 +144,7 @@ const workspacePageMemoryCache = new Map<
 const tableNotesMemoryCache = new Map<string, any[]>();
 const tablePdfsMemoryCache = new Map<string, any[]>();
 const tableLinksMemoryCache = new Map<string, any[]>();
+const tableWhiteboardsMemoryCache = new Map<string, any[]>();
 
 type ViewMode = "grid" | "list" | "calendar";
 type CalendarZoom = "week" | "month" | "quarter" | "year";
@@ -149,6 +152,7 @@ type ContentFilter =
   | "all"
   | "note"
   | "pdf"
+  | "whiteboard"
   | "youtube"
   | "x"
   | "instagram"
@@ -164,6 +168,7 @@ const CONTENT_FILTER_OPTIONS: {
   { value: "all", label: "All" },
   { value: "note", label: "Notes" },
   { value: "pdf", label: "PDFs" },
+  { value: "whiteboard", label: "Whiteboards" },
   { value: "youtube", label: "YouTube" },
   { value: "x", label: "X" },
   { value: "instagram", label: "Instagram" },
@@ -363,7 +368,19 @@ interface LinkItem {
   kind: "link";
 }
 
-type WorkspaceEntry = (Note & { kind: "note" }) | PdfItem | LinkItem;
+interface WhiteboardItem {
+  _id: Id<"whiteboards">;
+  title: string;
+  preview?: string;
+  userId: Id<"users">;
+  workingSpaceId: Id<"workingSpaces">;
+  notesTableId: Id<"notesTables">;
+  createdAt: number;
+  updatedAt: number;
+  kind: "whiteboard";
+}
+
+type WorkspaceEntry = (Note & { kind: "note" }) | PdfItem | LinkItem | WhiteboardItem;
 
 interface NotesDroppableContainerProps {
   tableId: Id<"notesTables">;
@@ -418,6 +435,12 @@ interface PdfCardProps {
 interface LinkCardProps {
   link: LinkItem;
   onDelete?: (linkId: Id<"links">) => void;
+  searchQuery?: string;
+}
+
+interface WhiteboardCardProps {
+  whiteboard: WhiteboardItem;
+  onDelete?: (whiteboardId: Id<"whiteboards">) => void;
   searchQuery?: string;
 }
 
@@ -1436,6 +1459,19 @@ export function NotesDroppableContainer({
     status: "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
     loadMore: (numItems: number) => void;
   };
+  const {
+    results: whiteboardResults,
+    status: whiteboardsStatus,
+    loadMore: loadMoreWhiteboards,
+  } = usePaginatedQuery(
+    api.whiteboards.getWhiteboardsByTableId,
+    { notesTableId: tableId },
+    { initialNumItems: 5 },
+  ) as {
+    results: Array<Omit<WhiteboardItem, "kind">>;
+    status: "LoadingFirstPage" | "CanLoadMore" | "LoadingMore" | "Exhausted";
+    loadMore: (numItems: number) => void;
+  };
 
   const cachedNotes = tableNotesMemoryCache.get(tableId as unknown as string);
   useEffect(() => {
@@ -1468,8 +1504,24 @@ export function NotesDroppableContainer({
       ? cachedLinks
       : linkResults;
 
+  const cachedWhiteboards = tableWhiteboardsMemoryCache.get(
+    tableId as unknown as string,
+  );
+  useEffect(() => {
+    if (whiteboardsStatus !== "LoadingFirstPage") {
+      tableWhiteboardsMemoryCache.set(
+        tableId as unknown as string,
+        whiteboardResults,
+      );
+    }
+  }, [tableId, whiteboardResults, whiteboardsStatus]);
+  const stableWhiteboards =
+    whiteboardsStatus === "LoadingFirstPage" && cachedWhiteboards
+      ? cachedWhiteboards
+      : whiteboardResults;
+
   // Single combined pagination state driving one "Show More" button for
-  // notes + pdfs + links together.
+  // notes + pdfs + links + whiteboards together.
   const aggregateStatus:
     | "LoadingFirstPage"
     | "CanLoadMore"
@@ -1480,11 +1532,13 @@ export function NotesDroppableContainer({
     pdfsStatus === "LoadingFirstPage" &&
     !cachedPdfs &&
     linksStatus === "LoadingFirstPage" &&
-    !cachedLinks
+    !cachedLinks &&
+    whiteboardsStatus === "LoadingFirstPage" &&
+    !cachedWhiteboards
       ? "LoadingFirstPage"
-      : [notesStatus, pdfsStatus, linksStatus].some((s) => s === "CanLoadMore")
+      : [notesStatus, pdfsStatus, linksStatus, whiteboardsStatus].some((s) => s === "CanLoadMore")
         ? "CanLoadMore"
-        : [notesStatus, pdfsStatus, linksStatus].some(
+        : [notesStatus, pdfsStatus, linksStatus, whiteboardsStatus].some(
               (s) => s === "LoadingMore",
             )
           ? "LoadingMore"
@@ -1494,6 +1548,7 @@ export function NotesDroppableContainer({
     if (notesStatus === "CanLoadMore") loadMoreNotes(15);
     if (pdfsStatus === "CanLoadMore") loadMorePdfs(15);
     if (linksStatus === "CanLoadMore") loadMoreLinks(15);
+    if (whiteboardsStatus === "CanLoadMore") loadMoreWhiteboards(15);
   }, [
     notesStatus,
     pdfsStatus,
@@ -1501,6 +1556,8 @@ export function NotesDroppableContainer({
     loadMoreNotes,
     loadMorePdfs,
     loadMoreLinks,
+    loadMoreWhiteboards,
+    whiteboardsStatus,
   ]);
 
   const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
@@ -1628,7 +1685,10 @@ export function NotesDroppableContainer({
     const linkItems = stableLinks.map(
       (link) => ({ ...link, kind: "link" }) as WorkspaceEntry,
     );
-    let items = [...noteItems, ...pdfItems, ...linkItems]
+    const whiteboardItems = stableWhiteboards.map(
+      (whiteboard) => ({ ...whiteboard, kind: "whiteboard" }) as WorkspaceEntry,
+    );
+    let items = [...noteItems, ...pdfItems, ...linkItems, ...whiteboardItems]
       .filter((item) => item && !deletedItemIds.has(item._id))
       .sort((a, b) => b.updatedAt - a.updatedAt);
 
@@ -1636,6 +1696,7 @@ export function NotesDroppableContainer({
       items = items.filter((item) => {
         if (contentFilter === "note") return item.kind === "note";
         if (contentFilter === "pdf") return item.kind === "pdf";
+        if (contentFilter === "whiteboard") return item.kind === "whiteboard";
         if (item.kind !== "link") return false;
         return matchesLinkPlatform(item.platform, contentFilter);
       });
@@ -1654,6 +1715,9 @@ export function NotesDroppableContainer({
     return items.filter((item) => {
       const titleMatches = item.title?.toLowerCase().includes(q);
       if (item.kind === "pdf") return titleMatches;
+      if (item.kind === "whiteboard") {
+        return titleMatches || item.preview?.toLowerCase().includes(q);
+      }
       if (item.kind === "link") {
         return titleMatches || item.url.toLowerCase().includes(q);
       }
@@ -1667,6 +1731,7 @@ export function NotesDroppableContainer({
     deletedItemIds,
     stableLinks,
     stablePdfs,
+    stableWhiteboards,
     searchQuery,
     stableResults,
   ]);
@@ -1997,7 +2062,21 @@ export function NotesDroppableContainer({
                           "opacity-40 scale-[0.98] transition-transform",
                       )}
                     >
-                      {item.kind === "pdf" ? (
+                      {item.kind === "whiteboard" ? (
+                        isGridLayout ? (
+                          <WhiteboardGridCard
+                            whiteboard={item}
+                            onDelete={handleItemDelete as (whiteboardId: Id<"whiteboards">) => void}
+                            searchQuery={searchQuery}
+                          />
+                        ) : (
+                          <WhiteboardListCard
+                            whiteboard={item}
+                            onDelete={handleItemDelete as (whiteboardId: Id<"whiteboards">) => void}
+                            searchQuery={searchQuery}
+                          />
+                        )
+                      ) : item.kind === "pdf" ? (
                         isGridLayout ? (
                           <PdfGridCard
                             pdf={item}
@@ -2726,6 +2805,7 @@ function CalendarGapMarker({
 function TimelineMiniThumbnail({ item }: { item: WorkspaceEntry }) {
   const [imgLoaded, setImgLoaded] = useState(false);
   const isLink = item.kind === "link";
+  const isWhiteboard = item.kind === "whiteboard";
   const thumbnailUrl = isLink
     ? (item as LinkItem).metadata?.thumbnailUrl
     : undefined;
@@ -2735,7 +2815,11 @@ function TimelineMiniThumbnail({ item }: { item: WorkspaceEntry }) {
   if (!isLink) {
     return (
       <div className="h-9 w-9 flex items-center justify-center flex-shrink-0 app-radius-md bg-muted">
-        <FileText className="h-4 w-4 text-muted-foreground" />
+        {isWhiteboard ? (
+          <PanelTop className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <FileText className="h-4 w-4 text-muted-foreground" />
+        )}
       </div>
     );
   }
@@ -2785,7 +2869,12 @@ function TimelineMiniCard({
 }) {
   const isPdf = item.kind === "pdf";
   const isLink = item.kind === "link";
-  const href = isPdf
+  const isWhiteboard = item.kind === "whiteboard";
+  const href = isWhiteboard
+    ? `/home/${(item as WhiteboardItem).workingSpaceId}/whiteboard/${generateSlug(
+        (item as WhiteboardItem).title || "untitled-whiteboard",
+      )}?whiteboardId=${item._id}`
+    : isPdf
     ? `/home/${(item as PdfItem).workingSpaceId}/pdf/${generateSlug(
         (item as PdfItem).title || "untitled-pdf",
       )}?pdfId=${item._id}`
@@ -3389,6 +3478,110 @@ const PdfListCard = memo(function PdfListCard({
               </IntentPrefetchLink>
             </Button>
           </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+});
+
+function WhiteboardPreview({ preview }: { preview?: string }) {
+  return (
+    <div className="relative flex h-24 w-full items-center justify-center overflow-hidden border border-border bg-[linear-gradient(hsl(var(--border)/.45)_1px,transparent_1px),linear-gradient(90deg,hsl(var(--border)/.45)_1px,transparent_1px)] bg-[size:18px_18px]">
+      <PanelTop className="h-8 w-8 text-primary/70" />
+      <span className="absolute bottom-2 left-2 bg-card/90 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+        {preview || "Empty canvas"}
+      </span>
+    </div>
+  );
+}
+
+const WhiteboardGridCard = memo(function WhiteboardGridCard({
+  whiteboard,
+  onDelete,
+  searchQuery,
+}: WhiteboardCardProps) {
+  const deleteWhiteboard = useMutation(api.whiteboards.deleteWhiteboard);
+  const whiteboardHref = `/home/${whiteboard.workingSpaceId}/whiteboard/${generateSlug(
+    whiteboard.title || "untitled-whiteboard",
+  )}?whiteboardId=${whiteboard._id}`;
+
+  const handleDelete = async () => {
+    await deleteWhiteboard({ _id: whiteboard._id });
+    onDelete?.(whiteboard._id);
+  };
+
+  return (
+    <Card className="group relative overflow-hidden bg-card border border-border flex flex-col w-full min-h-[200px]">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-lg font-semibold text-foreground line-clamp-2">
+            <HighlightText text={whiteboard.title || "Untitled whiteboard"} query={searchQuery} />
+          </CardTitle>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground hover:text-destructive"
+            aria-label="delete-whiteboard"
+            onClick={() => void handleDelete()}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="flex-grow flex-1">
+        <WhiteboardPreview preview={whiteboard.preview} />
+      </CardContent>
+      <CardFooter className="py-2 px-3 flex items-center justify-between border-t border-border">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Calendar className="h-3.5 w-3.5" />
+          <span>{new Date(whiteboard.updatedAt).toLocaleDateString()}</span>
+        </div>
+        <Button size="sm" asChild variant="revDefault" className="h-9 px-6 text-xs" aria-label="open-whiteboard">
+          <IntentPrefetchLink href={whiteboardHref}>Open</IntentPrefetchLink>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+});
+
+const WhiteboardListCard = memo(function WhiteboardListCard({
+  whiteboard,
+  onDelete,
+  searchQuery,
+}: WhiteboardCardProps) {
+  const deleteWhiteboard = useMutation(api.whiteboards.deleteWhiteboard);
+  const whiteboardHref = `/home/${whiteboard.workingSpaceId}/whiteboard/${generateSlug(
+    whiteboard.title || "untitled-whiteboard",
+  )}?whiteboardId=${whiteboard._id}`;
+
+  const handleDelete = async () => {
+    await deleteWhiteboard({ _id: whiteboard._id });
+    onDelete?.(whiteboard._id);
+  };
+
+  return (
+    <Card className="relative flex min-h-[100px] items-center border border-border bg-card">
+      <CardContent className="flex w-full items-center gap-4 p-3">
+        <div className="h-10 w-10 shrink-0 overflow-hidden">
+          <WhiteboardPreview preview={undefined} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-lg font-semibold text-foreground line-clamp-1">
+            <HighlightText text={whiteboard.title || "Untitled whiteboard"} query={searchQuery} />
+          </h3>
+          <p className="text-sm text-muted-foreground">{whiteboard.preview || "Empty canvas"}</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground">
+            <Calendar className="h-3.5 w-3.5" />
+            {new Date(whiteboard.updatedAt).toLocaleDateString()}
+          </span>
+          <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive" aria-label="delete-whiteboard" onClick={() => void handleDelete()}>
+            <Trash2 className="h-4 w-4" />
+          </Button>
+          <Button size="sm" asChild variant="revDefault" className="h-8 px-3 text-xs">
+            <IntentPrefetchLink href={whiteboardHref}>Open</IntentPrefetchLink>
+          </Button>
         </div>
       </CardContent>
     </Card>

--- a/app/home/[id]/whiteboard/[whiteboardId]/WhiteboardPageClient.tsx
+++ b/app/home/[id]/whiteboard/[whiteboardId]/WhiteboardPageClient.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getSnapshot, loadSnapshot, Tldraw, type Editor } from "tldraw";
+import { useMutation } from "convex/react";
+import { useQuery } from "@/cache/useQuery";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { Input } from "@/components/ui/input";
+import { useDebouncedCallback } from "use-debounce";
+import { useTheme } from "next-themes";
+
+function getPreview(snapshot: string) {
+  try {
+    const data = JSON.parse(snapshot);
+    const records = Object.values(data?.store ?? data ?? {}) as Array<{
+      typeName?: string;
+    }>;
+    const shapes = records.filter(
+      (record) => record.typeName === "shape",
+    ).length;
+    return shapes === 1 ? "1 shape" : `${shapes} shapes`;
+  } catch {
+    return "Canvas updated";
+  }
+}
+
+export default function WhiteboardPageClient({
+  whiteboardId,
+}: {
+  whiteboardId: Id<"whiteboards">;
+}) {
+  const whiteboard = useQuery(api.whiteboards.getWhiteboardById, {
+    _id: whiteboardId,
+  });
+  const updateWhiteboard = useMutation(api.whiteboards.updateWhiteboard);
+  const editorRef = useRef<Editor | null>(null);
+  const { resolvedTheme } = useTheme();
+  const colorScheme = resolvedTheme === "dark" ? "dark" : "light";
+  const [title, setTitle] = useState("");
+  const [saveState, setSaveState] = useState<"saved" | "saving">("saved");
+
+  useEffect(() => {
+    if (whiteboard) setTitle(whiteboard.title);
+  }, [whiteboard]);
+
+  const saveSnapshot = useDebouncedCallback(async (snapshot: string) => {
+    setSaveState("saving");
+    try {
+      await updateWhiteboard({
+        _id: whiteboardId,
+        snapshot,
+        preview: getPreview(snapshot),
+      });
+    } finally {
+      setSaveState("saved");
+    }
+  }, 700);
+
+  const saveTitle = useDebouncedCallback((nextTitle: string) => {
+    const trimmed = nextTitle.trim();
+    if (trimmed) void updateWhiteboard({ _id: whiteboardId, title: trimmed });
+  }, 400);
+
+  const handleMount = useCallback(
+    (editor: Editor) => {
+      editorRef.current = editor;
+      editor.user.updateUserPreferences({ colorScheme });
+      if (whiteboard?.snapshot) {
+        try {
+          loadSnapshot(editor.store, JSON.parse(whiteboard.snapshot));
+        } catch {
+          // A malformed legacy snapshot should not prevent a fresh board.
+        }
+      }
+      return editor.store.listen(
+        () => {
+          const snapshot = JSON.stringify(getSnapshot(editor.store));
+          saveSnapshot(snapshot);
+        },
+        { source: "user", scope: "document" },
+      );
+    },
+    [colorScheme, saveSnapshot, whiteboard?.snapshot],
+  );
+
+  useEffect(() => {
+    editorRef.current?.user.updateUserPreferences({ colorScheme });
+  }, [colorScheme]);
+
+  useEffect(() => {
+    if (!whiteboard?.title) return;
+    const originalTitle = document.title;
+    document.title = `${whiteboard.title} - Notevo Whiteboard`;
+    return () => {
+      document.title = originalTitle;
+    };
+  }, [whiteboard?.title]);
+
+  useEffect(
+    () => () => {
+      saveSnapshot.flush();
+    },
+    [saveSnapshot],
+  );
+
+  const canvas = useMemo(
+    () => (
+      <Tldraw
+        key={whiteboardId}
+        colorScheme={colorScheme}
+        onMount={handleMount}
+        components={{
+          MainMenu: null,
+          PageMenu: null,
+          QuickActions: null,
+        }}
+      />
+    ),
+    [colorScheme, handleMount, whiteboardId],
+  );
+
+  if (whiteboard === undefined) {
+    return <div className="h-full min-h-[60vh] animate-pulse bg-card" />;
+  }
+
+  return (
+    <div className="whiteboard-canvas relative h-full min-h-[calc(100vh-4rem)] w-full overflow-hidden bg-background">
+      {canvas}
+    </div>
+  );
+}

--- a/app/home/[id]/whiteboard/[whiteboardId]/page.tsx
+++ b/app/home/[id]/whiteboard/[whiteboardId]/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import type { Id } from "@/convex/_generated/dataModel";
+import WhiteboardPageClient from "./WhiteboardPageClient";
+
+export default async function WhiteboardPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ whiteboardId?: string }>;
+  searchParams: Promise<{ whiteboardId?: string | string[] }>;
+}) {
+  const { whiteboardId: routeId } = await params;
+  const { whiteboardId } = await searchParams;
+  const resolvedId =
+    typeof whiteboardId === "string"
+      ? whiteboardId
+      : Array.isArray(whiteboardId)
+        ? whiteboardId[0]
+        : routeId;
+
+  if (!resolvedId) redirect("/");
+  return <WhiteboardPageClient whiteboardId={resolvedId as Id<"whiteboards">} />;
+}

--- a/components/home-components/HomeClientLayout.tsx
+++ b/components/home-components/HomeClientLayout.tsx
@@ -66,6 +66,7 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
   const pdfId = searchParams.get("pdfId") as Id<"pdfs"> | null;
   const noteTitle = parseSlug(`${pathSegments[2]}`);
   const isPdfRoute = pathSegments[2] === "pdf";
+  const isWhiteboardRoute = pathSegments[2] === "whiteboard";
   const currentPdf = useQuery(
     api.pdfs.getPdfById,
     pdfId ? { _id: pdfId } : "skip",
@@ -127,7 +128,9 @@ const HomeContent = memo(({ children }: { children: ReactNode }) => {
         <div
           ref={scrollContainerRef}
           className={`scrollbar-gutter-stable min-h-0 flex-1 [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-track]:bg-transparent ${
-            isPdfRoute ? "overflow-hidden pt-0" : "overflow-y-auto py-16"
+            isPdfRoute || isWhiteboardRoute
+              ? "overflow-hidden py-0"
+              : "overflow-y-auto py-16"
           }`}
         >
           <motion.div

--- a/components/home-components/workingspace-new-dropdown-btn.tsx
+++ b/components/home-components/workingspace-new-dropdown-btn.tsx
@@ -9,7 +9,7 @@ import {
   type ChangeEvent,
 } from "react";
 import { insertAtTop, useAction, useMutation } from "convex/react";
-import { ChevronDown, FileUp, FileText, Link2 } from "lucide-react";
+import { ChevronDown, FileUp, FileText, Link2, PanelTop } from "lucide-react";
 import type { Id } from "@/convex/_generated/dataModel";
 import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
@@ -44,7 +44,7 @@ import {
   type LinkPlatform,
 } from "@/lib/link-platform";
 
-type PreferredAction = "note" | "upload" | "link";
+type PreferredAction = "note" | "upload" | "link" | "whiteboard";
 
 const STORAGE_KEY = "notevo_workspace_primary_create_action";
 
@@ -125,7 +125,8 @@ export default function WorkingspaceNewDropdownBtn({
     if (
       savedAction === "note" ||
       savedAction === "upload" ||
-      savedAction === "link"
+      savedAction === "link" ||
+      savedAction === "whiteboard"
     ) {
       setPreferredAction(savedAction);
     }
@@ -176,6 +177,7 @@ export default function WorkingspaceNewDropdownBtn({
   const generateUploadUrl = useMutation(api.pdfs.generateUploadUrl);
   const sendPdf = useMutation(api.pdfs.sendPdf);
   const createLink = useMutation(api.links.createLink);
+  const createWhiteboard = useMutation(api.whiteboards.createWhiteboard);
   const fetchLinkMetadata = useAction(api.Linkmetadata.fetchLinkMetadata);
 
   const isDisabled = useMemo(
@@ -202,6 +204,24 @@ export default function WorkingspaceNewDropdownBtn({
       });
     }
   }, [createNote, notesTableId, toast, workingSpaceId, workingSpacesSlug]);
+
+  const handleCreateWhiteboard = useCallback(async () => {
+    if (!notesTableId || !workingSpaceId) return;
+    try {
+      await createWhiteboard({
+        title: "Untitled whiteboard",
+        notesTableId,
+        workingSpaceId,
+      });
+    } catch (error) {
+      console.error("Failed to create whiteboard:", error);
+      toast({
+        title: "Could not create whiteboard",
+        description: "Please try again.",
+        variant: "destructive",
+      });
+    }
+  }, [createWhiteboard, notesTableId, toast, workingSpaceId]);
 
   const uploadPdfFile = useCallback(
     async (file: File) => {
@@ -351,6 +371,11 @@ export default function WorkingspaceNewDropdownBtn({
       return;
     }
 
+    if (preferredAction === "whiteboard") {
+      await handleCreateWhiteboard();
+      return;
+    }
+
     await handleCreateNote();
   }, [handleCreateNote, handleSelectInsertLink, preferredAction]);
 
@@ -373,6 +398,11 @@ export default function WorkingspaceNewDropdownBtn({
     persistPreferredAction("upload");
     fileInputRef.current?.click();
   }, [persistPreferredAction]);
+
+  const handleSelectWhiteboard = useCallback(async () => {
+    persistPreferredAction("whiteboard");
+    await handleCreateWhiteboard();
+  }, [handleCreateWhiteboard, persistPreferredAction]);
 
   useEffect(() => {
     const handlerCreateNoteShortcut = (e: KeyboardEvent) => {
@@ -475,6 +505,10 @@ export default function WorkingspaceNewDropdownBtn({
             <DropdownMenuItem onClick={handleSelectUpload}>
               <FileUp className="h-4 w-4 text-muted-foreground" />
               Upload PDF
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => void handleSelectWhiteboard()}>
+              <PanelTop className="h-4 w-4 text-muted-foreground" />
+              New Whiteboard
             </DropdownMenuItem>
             <DropdownMenuItem
               className="justify-between"

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -21,6 +21,7 @@ import type * as otp_ResendOTP from "../otp/ResendOTP.js";
 import type * as otp_VerificationCodeEmail from "../otp/VerificationCodeEmail.js";
 import type * as pdfs from "../pdfs.js";
 import type * as users from "../users.js";
+import type * as whiteboards from "../whiteboards.js";
 import type * as workingSpaces from "../workingSpaces.js";
 
 import type {
@@ -43,6 +44,7 @@ declare const fullApi: ApiFromModules<{
   "otp/VerificationCodeEmail": typeof otp_VerificationCodeEmail;
   pdfs: typeof pdfs;
   users: typeof users;
+  whiteboards: typeof whiteboards;
   workingSpaces: typeof workingSpaces;
 }>;
 

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -533,12 +533,20 @@ export const getWorkspaceTree = query({
                 )
                 .order("desc")
                 .collect();
+              const allWhiteboards = await ctx.db
+                .query("whiteboards")
+                .withIndex("by_notesTableId", (q) =>
+                  q.eq("notesTableId", table._id),
+                )
+                .order("desc")
+                .collect();
 
               return {
                 ...table,
                 notes: allNotes.map(({ body, ...rest }) => rest),
                 pdfs: allPdfs,
                 links: allLinks,
+                whiteboards: allWhiteboards,
               };
             }
 
@@ -563,12 +571,20 @@ export const getWorkspaceTree = query({
               )
               .order("desc")
               .take(TREE_NOTES_PER_TABLE);
+            const firstWhiteboards = await ctx.db
+              .query("whiteboards")
+              .withIndex("by_notesTableId", (q) =>
+                q.eq("notesTableId", table._id),
+              )
+              .order("desc")
+              .take(TREE_NOTES_PER_TABLE);
 
             return {
               ...table,
               notes: firstNotes.map(({ body, ...rest }) => rest),
               pdfs: firstPdfs,
               links: firstLinks,
+              whiteboards: firstWhiteboards,
             };
           }),
         );
@@ -578,7 +594,8 @@ export const getWorkspaceTree = query({
           (table) =>
             table.notes.length > 0 ||
             table.pdfs.length > 0 ||
-            (table.links?.length ?? 0) > 0,
+            (table.links?.length ?? 0) > 0 ||
+            (table.whiteboards?.length ?? 0) > 0,
         );
 
         // Drop workspace entirely if it has no non-empty tables
@@ -607,18 +624,24 @@ export const getWorkspaceTree = query({
             const matchingLinks = (table.links ?? []).filter((link: any) =>
               normalizeSearchText(link.title).includes(normalizedQuery),
             );
+            const matchingWhiteboards = (table.whiteboards ?? []).filter(
+              (whiteboard: any) =>
+                normalizeSearchText(whiteboard.title).includes(normalizedQuery),
+            );
 
             if (tableMatches) return table;
             if (
               matchingNotes.length > 0 ||
               matchingPdfs.length > 0 ||
-              matchingLinks.length > 0
+              matchingLinks.length > 0 ||
+              matchingWhiteboards.length > 0
             )
               return {
                 ...table,
                 notes: matchingNotes,
                 pdfs: matchingPdfs,
                 links: matchingLinks,
+                whiteboards: matchingWhiteboards,
               };
 
             return null;

--- a/convex/notesTables.ts
+++ b/convex/notesTables.ts
@@ -222,6 +222,10 @@ export const deleteTable = mutation({
       .query("pdfs")
       .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
       .collect();
+    const whiteboardsToDelete = await ctx.db
+      .query("whiteboards")
+      .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
+      .collect();
 
     for (const note of notesToDelete) {
       if (note.tags) {
@@ -235,6 +239,10 @@ export const deleteTable = mutation({
     for (const pdf of pdfsToDelete) {
       await ctx.storage.delete(pdf.storageId);
       await ctx.db.delete(pdf._id);
+    }
+
+    for (const whiteboard of whiteboardsToDelete) {
+      await ctx.db.delete(whiteboard._id);
     }
 
     const linksToDelete = await ctx.db
@@ -383,7 +391,7 @@ export const moveTable = mutation({
       updatedAt: Date.now(),
     });
 
-    const [notesInTable, pdfsInTable, linksInTable] = await Promise.all([
+    const [notesInTable, pdfsInTable, linksInTable, whiteboardsInTable] = await Promise.all([
       ctx.db
         .query("notes")
         .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
@@ -394,6 +402,10 @@ export const moveTable = mutation({
         .collect(),
       ctx.db
         .query("links")
+        .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
+        .collect(),
+      ctx.db
+        .query("whiteboards")
         .withIndex("by_notesTableId", (q) => q.eq("notesTableId", _id))
         .collect(),
     ]);
@@ -414,6 +426,12 @@ export const moveTable = mutation({
       ),
       ...linksInTable.map((link) =>
         ctx.db.patch(link._id, {
+          workingSpaceId: targetWorkingSpaceId,
+          updatedAt: Date.now(),
+        }),
+      ),
+      ...whiteboardsInTable.map((whiteboard) =>
+        ctx.db.patch(whiteboard._id, {
           workingSpaceId: targetWorkingSpaceId,
           updatedAt: Date.now(),
         }),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -72,6 +72,22 @@ export default defineSchema({
     .index("by_workingSpaceId", ["workingSpaceId"])
     .index("by_notesTableId", ["notesTableId"]),
 
+  whiteboards: defineTable({
+    userId: v.id("users"),
+    workingSpaceId: v.id("workingSpaces"),
+    notesTableId: v.id("notesTables"),
+    title: v.string(),
+    // A serialized tldraw editor snapshot. Keeping this with the board makes
+    // each canvas available wherever the owner signs in.
+    snapshot: v.optional(v.string()),
+    preview: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_workingSpaceId", ["workingSpaceId"])
+    .index("by_notesTableId", ["notesTableId"]),
+
   links: defineTable({
     url: v.string(),
     platform: linkPlatformValidator,

--- a/convex/whiteboards.ts
+++ b/convex/whiteboards.ts
@@ -1,0 +1,97 @@
+import { ConvexError, v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { paginationOptsValidator } from "convex/server";
+
+async function requireOwner(ctx: any, whiteboardId: any) {
+  const userId = await getAuthUserId(ctx);
+  if (!userId) throw new ConvexError("Not authenticated");
+
+  const whiteboard = await ctx.db.get(whiteboardId);
+  if (!whiteboard || whiteboard.userId !== userId) {
+    throw new ConvexError("Whiteboard not found or not authorized");
+  }
+  return whiteboard;
+}
+
+export const createWhiteboard = mutation({
+  args: {
+    title: v.string(),
+    workingSpaceId: v.id("workingSpaces"),
+    notesTableId: v.id("notesTables"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new ConvexError("Not authenticated");
+
+    const [workspace, table] = await Promise.all([
+      ctx.db.get(args.workingSpaceId),
+      ctx.db.get(args.notesTableId),
+    ]);
+    if (!workspace || workspace.userId !== userId) {
+      throw new ConvexError("Workspace not found or not authorized");
+    }
+    if (!table || table.workingSpaceId !== args.workingSpaceId) {
+      throw new ConvexError("Table does not belong to the provided workspace");
+    }
+
+    const now = Date.now();
+    return await ctx.db.insert("whiteboards", {
+      userId,
+      workingSpaceId: args.workingSpaceId,
+      notesTableId: args.notesTableId,
+      title: args.title.trim() || "Untitled whiteboard",
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+export const getWhiteboardsByTableId = query({
+  args: { notesTableId: v.id("notesTables"), paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new ConvexError("Not authenticated");
+    const table = await ctx.db.get(args.notesTableId);
+    const workspace = table && (await ctx.db.get(table.workingSpaceId));
+    if (!table || !workspace || workspace.userId !== userId) {
+      throw new ConvexError("Table not found or not authorized");
+    }
+    return await ctx.db
+      .query("whiteboards")
+      .withIndex("by_notesTableId", (q) => q.eq("notesTableId", args.notesTableId))
+      .order("desc")
+      .paginate(args.paginationOpts);
+  },
+});
+
+export const getWhiteboardById = query({
+  args: { _id: v.id("whiteboards") },
+  handler: async (ctx, args) => await requireOwner(ctx, args._id),
+});
+
+export const updateWhiteboard = mutation({
+  args: {
+    _id: v.id("whiteboards"),
+    title: v.optional(v.string()),
+    snapshot: v.optional(v.string()),
+    preview: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const whiteboard = await requireOwner(ctx, args._id);
+    await ctx.db.patch(args._id, {
+      title: args.title === undefined ? whiteboard.title : args.title.trim() || "Untitled whiteboard",
+      snapshot: args.snapshot === undefined ? whiteboard.snapshot : args.snapshot,
+      preview: args.preview === undefined ? whiteboard.preview : args.preview,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+export const deleteWhiteboard = mutation({
+  args: { _id: v.id("whiteboards") },
+  handler: async (ctx, args) => {
+    await requireOwner(ctx, args._id);
+    await ctx.db.delete(args._id);
+  },
+});

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwind-scrollbar": "^2.1.0",
     "tailwindcss-animate": "^1.0.7",
+    "tldraw": "^5.4.2",
     "ts-pattern": "^5.6.2",
     "turndown": "^7.2.2",
     "use-debounce": "^10.0.4",


### PR DESCRIPTION
## changes
<img width="1569" height="929" alt="image" src="https://github.com/user-attachments/assets/5f1179ba-a625-44fd-ab92-f55b8899fa1e" />
<img width="992" height="252" alt="image" src="https://github.com/user-attachments/assets/720b1642-e1e2-4f43-8d71-581711463957" />


* Added `tldraw` and imported its styles for the new whiteboard canvas.
* Added custom tldraw theme overrides to match Notevo's existing colors, borders, buttons, and square-radius styling.
* Added the `whiteboards` table to the Convex schema with snapshots, previews, timestamps, and workspace/table relationships.
* Added whiteboards to workspace tree queries, search results, table deletion, and table moving.
* Added whiteboards as a new content filter alongside notes, PDFs, and links.
* Added whiteboard pagination and memory caching to the workspace content list.
* Added grid and list whiteboard cards with previews, dates, open actions, and delete actions.
* Added whiteboard routes and navigation from the workspace.
* Added `New Whiteboard` to the workspace creation dropdown and allowed it to be saved as the preferred creation action.
* Added whiteboard support to the timeline view with its own icon and route.
* Updated the home layout so whiteboard routes use the full available canvas without the normal page scrolling/padding.

This adds whiteboards as a first-class content type inside workspaces, instead of treating them as something separate from the existing notes, PDFs, and links.

The tldraw styling is also customized so the whiteboard feels like part of Notevo rather than an embedded editor with completely different UI styling.