### PR TITLE
add whiteboard asset uploads and safer saving

### DIFF
--- a/app/home/[id]/whiteboard/[whiteboardId]/WhiteboardPageClient.tsx
+++ b/app/home/[id]/whiteboard/[whiteboardId]/WhiteboardPageClient.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { getSnapshot, loadSnapshot, Tldraw, type Editor } from "tldraw";
+import {
+  getSnapshot,
+  loadSnapshot,
+  Tldraw,
+  type Editor,
+  type TLAsset,
+  type TLAssetStore,
+} from "tldraw";
 import { useMutation } from "convex/react";
 import { useQuery } from "@/cache/useQuery";
 import { api } from "@/convex/_generated/api";
@@ -34,11 +41,25 @@ export default function WhiteboardPageClient({
     _id: whiteboardId,
   });
   const updateWhiteboard = useMutation(api.whiteboards.updateWhiteboard);
+
+  const generateUploadUrl = useMutation(api.files.generateUploadUrl);
+  const getFileUrl = useMutation(api.files.getUrl);
+
   const editorRef = useRef<Editor | null>(null);
   const { resolvedTheme } = useTheme();
   const colorScheme = resolvedTheme === "dark" ? "dark" : "light";
   const [title, setTitle] = useState("");
-  const [saveState, setSaveState] = useState<"saved" | "saving">("saved");
+  const [saveState, setSaveState] = useState<"saved" | "saving" | "error">(
+    "saved",
+  );
+
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+
+  useEffect(() => {
+    if (whiteboard !== undefined) setHasLoadedOnce(true);
+  }, [whiteboard]);
+
+  const hasLoadedSnapshotRef = useRef(false);
 
   useEffect(() => {
     if (whiteboard) setTitle(whiteboard.title);
@@ -52,8 +73,10 @@ export default function WhiteboardPageClient({
         snapshot,
         preview: getPreview(snapshot),
       });
-    } finally {
       setSaveState("saved");
+    } catch (err) {
+      console.error("Failed to save whiteboard snapshot:", err);
+      setSaveState("error");
     }
   }, 700);
 
@@ -62,17 +85,38 @@ export default function WhiteboardPageClient({
     if (trimmed) void updateWhiteboard({ _id: whiteboardId, title: trimmed });
   }, 400);
 
+  const assetStore = useMemo<TLAssetStore>(
+    () => ({
+      async upload(_asset: TLAsset, file: File) {
+        const uploadUrl = await generateUploadUrl();
+        const result = await fetch(uploadUrl, {
+          method: "POST",
+          headers: { "Content-Type": file.type },
+          body: file,
+        });
+        if (!result.ok) {
+          throw new Error(`Upload failed with status ${result.status}`);
+        }
+        const { storageId } = await result.json();
+        const url = await getFileUrl({ storageId });
+        if (!url) throw new Error("Could not resolve uploaded file URL");
+        return { src: url };
+      },
+      resolve(asset: TLAsset) {
+        return asset.props.src;
+      },
+    }),
+    [generateUploadUrl, getFileUrl],
+  );
+
+  const [isEditorReady, setIsEditorReady] = useState(false);
+
   const handleMount = useCallback(
     (editor: Editor) => {
       editorRef.current = editor;
       editor.user.updateUserPreferences({ colorScheme });
-      if (whiteboard?.snapshot) {
-        try {
-          loadSnapshot(editor.store, JSON.parse(whiteboard.snapshot));
-        } catch {
-          // A malformed legacy snapshot should not prevent a fresh board.
-        }
-      }
+      setIsEditorReady(true);
+
       return editor.store.listen(
         () => {
           const snapshot = JSON.stringify(getSnapshot(editor.store));
@@ -81,8 +125,22 @@ export default function WhiteboardPageClient({
         { source: "user", scope: "document" },
       );
     },
-    [colorScheme, saveSnapshot, whiteboard?.snapshot],
+    [colorScheme, saveSnapshot],
   );
+
+  useEffect(() => {
+    if (!isEditorReady) return;
+    if (hasLoadedSnapshotRef.current) return;
+    const editor = editorRef.current;
+    if (!editor || !whiteboard?.snapshot) return;
+
+    try {
+      loadSnapshot(editor.store, JSON.parse(whiteboard.snapshot));
+    } catch {
+      // A malformed legacy snapshot should not prevent a fresh board.
+    }
+    hasLoadedSnapshotRef.current = true;
+  }, [isEditorReady, whiteboard?.snapshot]);
 
   useEffect(() => {
     editorRef.current?.user.updateUserPreferences({ colorScheme });
@@ -104,12 +162,34 @@ export default function WhiteboardPageClient({
     [saveSnapshot],
   );
 
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        saveSnapshot.flush();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [saveSnapshot]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (saveState === "saving") {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [saveState]);
+
   const canvas = useMemo(
     () => (
       <Tldraw
         key={whiteboardId}
         colorScheme={colorScheme}
         onMount={handleMount}
+        assets={assetStore}
         components={{
           MainMenu: null,
           PageMenu: null,
@@ -117,16 +197,21 @@ export default function WhiteboardPageClient({
         }}
       />
     ),
-    [colorScheme, handleMount, whiteboardId],
+    [colorScheme, handleMount, assetStore, whiteboardId],
   );
 
-  if (whiteboard === undefined) {
+  if (!hasLoadedOnce) {
     return <div className="h-full min-h-[60vh] animate-pulse bg-card" />;
   }
 
   return (
     <div className="whiteboard-canvas relative h-full min-h-[calc(100vh-4rem)] w-full overflow-hidden bg-background">
       {canvas}
+      {saveState === "error" && (
+        <div className="absolute bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-none border border-destructive bg-destructive/10 px-3 py-1.5 text-sm text-destructive">
+          Couldn't save your last change check your connection.
+        </div>
+      )}
     </div>
   );
 }

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as Linkmetadata from "../Linkmetadata.js";
 import type * as ResendMagicLink from "../ResendMagicLink.js";
 import type * as auth from "../auth.js";
+import type * as files from "../files.js";
 import type * as http from "../http.js";
 import type * as linkValidators from "../linkValidators.js";
 import type * as links from "../links.js";
@@ -34,6 +35,7 @@ declare const fullApi: ApiFromModules<{
   Linkmetadata: typeof Linkmetadata;
   ResendMagicLink: typeof ResendMagicLink;
   auth: typeof auth;
+  files: typeof files;
   http: typeof http;
   linkValidators: typeof linkValidators;
   links: typeof links;

--- a/convex/files.ts
+++ b/convex/files.ts
@@ -1,0 +1,23 @@
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const generateUploadUrl = mutation({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.storage.generateUploadUrl();
+  },
+});
+
+export const getUrl = mutation({
+  args: { storageId: v.id("_storage") },
+  handler: async (ctx, { storageId }) => {
+    return await ctx.storage.getUrl(storageId);
+  },
+});
+
+export const deleteFile = mutation({
+  args: { storageId: v.id("_storage") },
+  handler: async (ctx, { storageId }) => {
+    await ctx.storage.delete(storageId);
+  },
+});


### PR DESCRIPTION
## changes

* add a custom `TLAssetStore` to support uploading images and other whiteboard assets through Convex storage
* generate an upload URL, upload the file, then resolve the stored file URL so tldraw can display it on the canvas
* improve whiteboard loading so the saved snapshot is loaded only after the editor is ready
* prevent the initial editor mount from accidentally overwriting the existing whiteboard snapshot
* track an `error` save state and show a small connection error message when saving fails
* flush pending snapshot saves when the page becomes hidden so recent changes are less likely to be lost
* prevent navigation while a whiteboard save is still in progress
* expose the Convex `files` API through the generated API types

The whiteboard previously handled the canvas itself, but it didn't have proper asset uploading and there were a few edge cases around loading and saving snapshots.

This adds the missing asset storage flow and makes the save/load lifecycle safer, especially when opening an existing board or leaving the page quickly.

## better now

Whiteboards can now handle uploaded assets through Convex storage instead of relying only on the canvas state.

Snapshot loading is also more reliable because the saved board is restored after tldraw is ready, while pending changes are flushed when the page is hidden. Failed saves are surfaced to the user instead of silently failing, making the whiteboard experience more reliable overall.
