### PR TITLE
switch whiteboard from tldraw to excalidraw

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,178 +1,248 @@
-@import "tldraw/tldraw.css";
+@import "@excalidraw/excalidraw/index.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Custom Whiteboard Canvas App Theme Overrides */
-.whiteboard-canvas {
-  --tl-color-background: hsl(var(--background));
-  --tl-color-panel: hsl(var(--card));
-  --tl-color-panel-contrast: hsl(var(--popover));
-  --tl-color-low: hsl(var(--muted));
-  --tl-color-low-border: hsl(var(--border));
-  --tl-color-divider: hsl(var(--border));
-  --tl-color-text: hsl(var(--card-foreground));
-  --tl-color-text-0: hsl(var(--card-foreground));
-  --tl-color-text-1: hsl(var(--card-foreground));
-  --tl-color-text-3: hsl(var(--muted-foreground));
-  --tl-color-selected: hsl(var(--primary));
-  --tl-color-selected-contrast: hsl(var(--primary-foreground));
-  --tl-color-muted-1: hsl(var(--accent));
-  --tl-color-muted-2: hsl(var(--muted));
 
-  --tl-radius-0: 0;
-  --tl-radius-1: 0;
-  --tl-radius-2: 0;
-  --tl-radius-3: 0;
-  --tl-radius-4: 0;
+.whiteboard-canvas .excalidraw {
+  --ui-font: inherit;
+  --default-bg-color: hsl(var(--background));
+  --input-bg-color: hsl(var(--card));
+  --input-border-color: hsl(var(--border));
+  --input-hover-bg-color: hsl(var(--accent));
+  --input-label-color: hsl(var(--muted-foreground));
+  --island-bg-color: hsl(var(--card));
+  --popup-bg-color: hsl(var(--popover));
+  --popup-secondary-bg-color: hsl(var(--muted));
+  --popup-text-color: hsl(var(--popover-foreground));
+  --popup-text-inverted-color: hsl(var(--primary-foreground));
+  --overlay-bg-color: hsl(var(--background) / 0.78);
+  --default-border-color: hsl(var(--border));
+  --sidebar-border-color: hsl(var(--border));
+  --sidebar-bg-color: hsl(var(--card));
+  --dialog-border-color: hsl(var(--border));
+  --text-primary-color: hsl(var(--foreground));
+  --icon-fill-color: hsl(var(--foreground));
+  --keybinding-color: hsl(var(--muted-foreground));
+  --color-on-surface: hsl(var(--foreground));
+  --color-surface-lowest: hsl(var(--background));
+  --color-surface-low: hsl(var(--card));
+  --color-surface-mid: hsl(var(--muted));
+  --color-surface-high: hsl(var(--accent));
+  --color-primary: hsl(var(--primary));
+  --color-primary-darker: hsl(var(--primary) / 0.88);
+  --color-primary-darkest: hsl(var(--primary) / 0.76);
+  --color-primary-hover: hsl(var(--primary) / 0.9);
+  --color-primary-light: hsl(var(--primary) / 0.16);
+  --color-primary-light-darker: hsl(var(--primary) / 0.24);
+  --color-selection: hsl(var(--primary));
+  --color-brand-hover: hsl(var(--primary) / 0.9);
+  --color-brand-active: hsl(var(--primary));
+  --color-on-primary-container: hsl(var(--primary));
+  --color-surface-primary-container: hsl(var(--primary) / 0.16);
+  --button-gray-1: hsl(var(--card));
+  --button-gray-2: hsl(var(--accent));
+  --button-gray-3: hsl(var(--muted));
+  --button-hover-bg: hsl(var(--accent));
+  --button-active-bg: hsl(var(--muted));
+  --button-active-border: hsl(var(--primary));
+  --focus-highlight-color: hsl(var(--ring));
+  --scrollbar-thumb: hsl(var(--border));
+  --scrollbar-thumb-hover: hsl(var(--muted-foreground));
+  --border-radius-md: 0;
+  --border-radius-lg: 0;
+  --shadow-island: none;
+  --sidebar-shadow: none;
+  --modal-shadow: 0 12px 32px hsl(var(--foreground) / 0.14);
+  background: hsl(var(--background));
 }
 
-
-.whiteboard-canvas .tlui-style-panel .tlui-toolbar {
-  background-color: transparent !important;
-  border: none !important;
-  border-bottom: 1px solid hsl(var(--border)) !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
+.whiteboard-canvas .excalidraw .Island,
+.whiteboard-canvas .excalidraw .App-toolbar,
+.whiteboard-canvas .excalidraw .App-menu__left,
+.whiteboard-canvas .excalidraw .dropdown-menu,
+.whiteboard-canvas .excalidraw .popover,
+.whiteboard-canvas .excalidraw .Modal .Modal__content {
+  border: 1px solid hsl(var(--border));
+  box-shadow: none;
 }
 
-.whiteboard-canvas .tlui-style-panel__section:last-child .tlui-toolbar:last-child {
-  border-bottom: none !important;
+.whiteboard-canvas .excalidraw .range-wrapper {
+  --color-slider-track: hsl(var(--primary));
+  --button-bg: hsl(var(--muted));
 }
 
-/* Hide watermark, production tracking & attribution links */
-.whiteboard-canvas .tl-watermark_SEE-LICENSE,
-.whiteboard-canvas [data-testid*="tl-watermark"],
-.whiteboard-canvas .tl-watermark,
-.whiteboard-canvas .tlui-watermark,
-.whiteboard-canvas a[href*="tldraw.dev"] {
-  display: none !important;
-  opacity: 0 !important;
-  pointer-events: none !important;
-  visibility: hidden !important;
-}
-
-/* Whiteboard Panels, Toolbars & Menus background, border, & rounded styling */
-.whiteboard-canvas .tlui-toolbar,
-.whiteboard-canvas .tlui-menu-zone,
-.whiteboard-canvas .tlui-navigation-zone,
-.whiteboard-canvas .tlui-style-panel,
-.whiteboard-canvas .tlui-popover__content,
-.whiteboard-canvas .tlui-menu {
-  background-color: hsl(var(--card)) !important;
-  color: hsl(var(--card-foreground)) !important;
-  border: 1px solid hsl(var(--border)) !important;
-  border-radius: 0 !important;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
-}
-
-/* No .whiteboard-canvas scope — tooltips render outside it via a portal */
-.tlui-tooltip {
-  background-color: hsl(var(--muted)) !important;
-  color: hsl(var(--muted-foreground)) !important;
-  border: 1px solid hsl(var(--border)) !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-}
-
-.tlui-tooltip svg,
-.tlui-tooltip [data-radix-popper-arrow] {
-  display: none !important;
-}
-
-.whiteboard-canvas .tlui-minimap {
-  background-color: hsl(var(--background)) !important;
-}
-
-.whiteboard-canvas .tlui-navigation-panel::before {
-  background: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
-}
-
-.whiteboard-canvas .tlui-navigation-panel .tlui-toolbar {
-  background-color: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
-}
-
-/* Menu zone placement in bottom-right corner */
-.whiteboard-canvas .tlui-menu-zone {
-  position: absolute;
-  inset: auto 0.75rem calc(0.75rem + env(safe-area-inset-bottom)) auto;
-  z-index: var(--tl-layer-panels);
-}
-
-
-/* Base button styling inside whiteboard UI */
-.whiteboard-canvas .tlui-button {
-  border-radius: 0 !important;
-  transition: background-color 0.15s ease, color 0.15s ease !important;
-}
-
-/* Hover state for buttons & menu items */
-.whiteboard-canvas .tlui-button:hover:not(:disabled):not([data-disabled="true"]),
-.whiteboard-canvas .tlui-button[data-state="hover"] {
-  background-color: hsl(var(--accent)) !important;
-  color: hsl(var(--accent-foreground)) !important;
-}
-
-/* Active / Selected tool buttons — cover every state attribute tldraw may use */
-.whiteboard-canvas .tlui-button[data-state="selected"],
-.whiteboard-canvas .tlui-button[aria-pressed="true"],
-.whiteboard-canvas .tlui-button[data-selected="true"],
-.whiteboard-canvas .tlui-button[data-isactive="true"],
-.whiteboard-canvas .tlui-button__tool[data-state="selected"] {
-  background-color: hsl(var(--primary)) !important;
-  color: hsl(var(--primary-foreground)) !important;
-  border-radius: 0 !important;
-}
-
-.whiteboard-canvas .tlui-button::after,
-.whiteboard-canvas .tlui-toolbar-toggle-group-item::after {
-  background: transparent !important;
-  box-shadow: none !important;
-  border-radius: 0 !important;
-}
-
-.whiteboard-canvas .tlui-button__tool[aria-pressed="true"]::after,
-.whiteboard-canvas .tlui-button__tool[data-isactive="true"]::after,
-.whiteboard-canvas .tlui-button__tool[data-state="selected"]::after {
-  background-color: hsl(var(--primary)) !important;
-  border-radius: 0 !important;
-}
-
-.whiteboard-canvas .tlui-button[data-state="selected"] svg,
-.whiteboard-canvas .tlui-button[aria-pressed="true"] svg,
-.whiteboard-canvas .tlui-button[data-selected="true"] svg,
-.whiteboard-canvas .tlui-button[data-isactive="true"] svg {
-  color: hsl(var(--primary-foreground)) !important;
-  fill: currentColor;
-}
-
-/* Opacity slider */
-.whiteboard-canvas .tlui-slider__track {
-  background-color: hsl(var(--card)) !important;
-}
-
-.whiteboard-canvas .tlui-slider__range {
-  background-color: hsl(var(--primary)) !important;
-}
-
-.whiteboard-canvas .tlui-slider__thumb {
+.whiteboard-canvas .excalidraw .range-input::-webkit-slider-thumb {
   background-color: hsl(var(--background)) !important;
   border: 2px solid hsl(var(--primary)) !important;
-  border-radius: 50% !important;
 }
 
-.whiteboard-canvas .tlui-slider__thumb:focus-visible {
+.whiteboard-canvas .excalidraw .range-input::-moz-range-thumb {
+  background-color: hsl(var(--background)) !important;
+  border: 2px solid hsl(var(--primary)) !important;
+}
+
+.whiteboard-canvas .excalidraw .App-menu__left {
+  position: absolute;
+  inset: auto 1rem max(4rem, env(safe-area-inset-bottom)) -1rem;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: flex-end;
+  gap: 0;
+  z-index: var(--zIndex-layerUI);
+  max-height: 800px;
+}
+
+/* Excalidraw left properties panel – clean scrollbar */
+.whiteboard-canvas .excalidraw .App-menu__left {
+  overflow-x: hidden !important;
+  /* no horizontal scroll */
+  overflow-y: auto;
+  scrollbar-width: thin;
+  /* Firefox */
+  scrollbar-color: hsl(var(--border)) transparent;
+}
+
+/* WebKit */
+.whiteboard-canvas .excalidraw .App-menu__left::-webkit-scrollbar {
+  width: 6px;
+  height: 0;
+  /* kills horizontal scrollbar */
+}
+
+.whiteboard-canvas .excalidraw .App-menu__left::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.whiteboard-canvas .excalidraw .App-menu__left::-webkit-scrollbar-thumb {
+  background: hsl(var(--border));
+  border-radius: 0;
+}
+
+.whiteboard-canvas .excalidraw .App-menu__left::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground));
+}
+
+/* Remove the arrow buttons completely */
+.whiteboard-canvas .excalidraw .App-menu__left::-webkit-scrollbar-button {
+  display: none !important;
+  height: 0;
+  width: 0;
+}
+
+.whiteboard-canvas div.color-picker-container>div.color-picker__top-picks {
+  gap: 4;
+}
+
+.whiteboard-canvas div.color-picker-container>div.color-picker__top-picks>button.color-picker__button {
+  border-radius: 0;
+}
+
+/* Color swatches (stroke, background, fill) and their selection ring */
+.whiteboard-canvas .excalidraw .color-picker__button,
+.whiteboard-canvas .excalidraw .color-picker__button-outline {
+  --radius: 0;
+  border-radius: 0 !important;
+}
+
+.whiteboard-canvas .excalidraw .scroll-back-to-content {
+  position: fixed !important;
+  top: auto !important;
+  left: auto !important;
+  right: max(0rem, env(safe-area-inset-right)) !important;
+  bottom: max(1rem, env(safe-area-inset-bottom)) !important;
+  z-index: var(--zIndex-layerUI);
+  font-size: 0.8rem;
+  padding: 0.5rem;
+}
+
+.whiteboard-canvas .excalidraw .buttonList button,
+.whiteboard-canvas .excalidraw .buttonList label,
+.whiteboard-canvas .excalidraw .ToolIcon,
+.whiteboard-canvas .excalidraw .zIndexButton {
+  border-radius: 0 !important;
+}
+
+.whiteboard-canvas .excalidraw .color-picker__button:hover {
+  border-radius: 0 !important;
+}
+
+.whiteboard-canvas .excalidraw .ToolIcon__icon,
+.whiteboard-canvas .excalidraw button.standalone,
+.whiteboard-canvas .excalidraw .dropdown-select {
+  border-radius: 0;
+}
+
+.whiteboard-canvas .excalidraw .ToolIcon .ToolIcon_type_radio:checked+.ToolIcon__icon,
+.whiteboard-canvas .excalidraw .ToolIcon .ToolIcon_type_checkbox:checked+.ToolIcon__icon,
+.whiteboard-canvas .excalidraw button.standalone.active {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+
+.whiteboard-canvas .excalidraw .ToolIcon .ToolIcon_type_radio:checked+.ToolIcon__icon svg,
+.whiteboard-canvas .excalidraw .ToolIcon .ToolIcon_type_checkbox:checked+.ToolIcon__icon svg,
+.whiteboard-canvas .excalidraw button.standalone.active svg {
+  color: hsl(var(--primary-foreground));
+}
+
+div.layer-ui__wrapper__footer-right.zen-mode-transition {
+  display: none !important;
+
+}
+
+.App-toolbar__extra-tools-trigger {
+  display: none !important;
+}
+
+div.layer-ui__wrapper__top-right.zen-mode-transition {
+
+  display: none !important;
+
+}
+
+.whiteboard-canvas .excalidraw .App-menu_top {
+  position: absolute;
+  inset: auto 1rem max(1rem, env(safe-area-inset-bottom)) 1rem;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: flex-end;
+  gap: 0;
+  z-index: var(--zIndex-layerUI);
+}
+
+.whiteboard-canvas .excalidraw .App-menu_top .shapes-section {
+  grid-column: 2;
+  justify-self: center;
+}
+
+/* Excalidraw defaults to a downward menu because its toolbar is normally at
+   the top. The Notevo dock lives at the bottom, so its menus open upward. */
+.whiteboard-canvas .excalidraw .App-menu_top .dropdown-menu {
+  top: auto;
+  bottom: 100%;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+/* Keep the layout column for centering, but do not expose Excalidraw's main
+   menu because Notevo owns persistence and canvas-level actions. */
+.whiteboard-canvas .excalidraw .main-menu-trigger {
+  display: none !important;
+}
+
+@media (max-width: 640px) {
+  .whiteboard-canvas .excalidraw .App-menu_top {
+    inset-inline: 0.5rem;
+    bottom: max(0.5rem, env(safe-area-inset-bottom));
+  }
+}
+
+/* The global focus reset is useful for the app chrome; restore a visible,
+   token-aligned indicator inside the keyboard-driven drawing interface. */
+.whiteboard-canvas .excalidraw :focus-visible {
   outline: 2px solid hsl(var(--ring)) !important;
   outline-offset: 2px;
-}
-
-.whiteboard-canvas .tlui-slider__container {
-  background-color: hsl(var(--card)) !important;
-  padding: 0.2rem 0.5rem !important;
 }
 
 *:focus,

--- a/app/home/[id]/whiteboard/[whiteboardId]/WhiteboardPageClient.tsx
+++ b/app/home/[id]/whiteboard/[whiteboardId]/WhiteboardPageClient.tsx
@@ -1,34 +1,51 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  getSnapshot,
-  loadSnapshot,
-  Tldraw,
-  type Editor,
-  type TLAsset,
-  type TLAssetStore,
-} from "tldraw";
+import dynamic from "next/dynamic";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useMutation } from "convex/react";
 import { useQuery } from "@/cache/useQuery";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
-import { Input } from "@/components/ui/input";
 import { useDebouncedCallback } from "use-debounce";
 import { useTheme } from "next-themes";
+import type {
+  AppState,
+  BinaryFileData,
+  BinaryFiles,
+  ExcalidrawInitialDataState,
+} from "@excalidraw/excalidraw/types";
+import type { ExcalidrawElement } from "@excalidraw/excalidraw/element/types";
 
-function getPreview(snapshot: string) {
+const Excalidraw = dynamic(
+  async () => (await import("@excalidraw/excalidraw")).Excalidraw,
+  { ssr: false },
+);
+
+type WhiteboardSnapshot = Pick<
+  ExcalidrawInitialDataState,
+  "elements" | "appState" | "files"
+>;
+
+function getPreview(elements: readonly ExcalidrawElement[]) {
+  const shapeCount = elements.filter((element) => !element.isDeleted).length;
+  return shapeCount === 1 ? "1 shape" : `${shapeCount} shapes`;
+}
+
+function parseSnapshot(snapshot?: string): WhiteboardSnapshot | null {
+  if (!snapshot) return null;
+
   try {
-    const data = JSON.parse(snapshot);
-    const records = Object.values(data?.store ?? data ?? {}) as Array<{
-      typeName?: string;
-    }>;
-    const shapes = records.filter(
-      (record) => record.typeName === "shape",
-    ).length;
-    return shapes === 1 ? "1 shape" : `${shapes} shapes`;
+    const parsed = JSON.parse(snapshot) as WhiteboardSnapshot;
+    if (!Array.isArray(parsed.elements)) return null;
+
+    if (parsed.appState && typeof parsed.appState === "object") {
+      const { collaborators: _collaborators, ...appState } = parsed.appState;
+      return { ...parsed, appState };
+    }
+
+    return parsed;
   } catch {
-    return "Canvas updated";
+    return null;
   }
 }
 
@@ -41,110 +58,101 @@ export default function WhiteboardPageClient({
     _id: whiteboardId,
   });
   const updateWhiteboard = useMutation(api.whiteboards.updateWhiteboard);
-
   const generateUploadUrl = useMutation(api.files.generateUploadUrl);
   const getFileUrl = useMutation(api.files.getUrl);
-
-  const editorRef = useRef<Editor | null>(null);
   const { resolvedTheme } = useTheme();
-  const colorScheme = resolvedTheme === "dark" ? "dark" : "light";
-  const [title, setTitle] = useState("");
+
   const [saveState, setSaveState] = useState<"saved" | "saving" | "error">(
     "saved",
   );
+  const uploadUrlsByFileId = useRef(new Map<string, Promise<string>>());
 
-  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+  const uploadFile = useCallback(
+    async (file: BinaryFileData) => {
+      if (!file.dataURL.startsWith("data:")) return file.dataURL as string;
 
-  useEffect(() => {
-    if (whiteboard !== undefined) setHasLoadedOnce(true);
-  }, [whiteboard]);
+      const pendingUpload = uploadUrlsByFileId.current.get(file.id);
+      if (pendingUpload) return pendingUpload;
 
-  const hasLoadedSnapshotRef = useRef(false);
-
-  useEffect(() => {
-    if (whiteboard) setTitle(whiteboard.title);
-  }, [whiteboard]);
-
-  const saveSnapshot = useDebouncedCallback(async (snapshot: string) => {
-    setSaveState("saving");
-    try {
-      await updateWhiteboard({
-        _id: whiteboardId,
-        snapshot,
-        preview: getPreview(snapshot),
-      });
-      setSaveState("saved");
-    } catch (err) {
-      console.error("Failed to save whiteboard snapshot:", err);
-      setSaveState("error");
-    }
-  }, 700);
-
-  const saveTitle = useDebouncedCallback((nextTitle: string) => {
-    const trimmed = nextTitle.trim();
-    if (trimmed) void updateWhiteboard({ _id: whiteboardId, title: trimmed });
-  }, 400);
-
-  const assetStore = useMemo<TLAssetStore>(
-    () => ({
-      async upload(_asset: TLAsset, file: File) {
+      const upload = (async () => {
+        const response = await fetch(file.dataURL);
+        const blob = await response.blob();
         const uploadUrl = await generateUploadUrl();
         const result = await fetch(uploadUrl, {
           method: "POST",
-          headers: { "Content-Type": file.type },
-          body: file,
+          headers: { "Content-Type": file.mimeType },
+          body: blob,
         });
         if (!result.ok) {
-          throw new Error(`Upload failed with status ${result.status}`);
+          throw new Error(`Image upload failed with status ${result.status}`);
         }
         const { storageId } = await result.json();
         const url = await getFileUrl({ storageId });
-        if (!url) throw new Error("Could not resolve uploaded file URL");
-        return { src: url };
-      },
-      resolve(asset: TLAsset) {
-        return asset.props.src;
-      },
-    }),
+        if (!url) throw new Error("Could not resolve uploaded image URL");
+        return url;
+      })();
+
+      uploadUrlsByFileId.current.set(file.id, upload);
+      try {
+        return await upload;
+      } catch (error) {
+        uploadUrlsByFileId.current.delete(file.id);
+        throw error;
+      }
+    },
     [generateUploadUrl, getFileUrl],
   );
 
-  const [isEditorReady, setIsEditorReady] = useState(false);
-
-  const handleMount = useCallback(
-    (editor: Editor) => {
-      editorRef.current = editor;
-      editor.user.updateUserPreferences({ colorScheme });
-      setIsEditorReady(true);
-
-      return editor.store.listen(
-        () => {
-          const snapshot = JSON.stringify(getSnapshot(editor.store));
-          saveSnapshot(snapshot);
-        },
-        { source: "user", scope: "document" },
-      );
+  const saveScene = useDebouncedCallback(
+    async (
+      elements: readonly ExcalidrawElement[],
+      appState: AppState,
+      files: BinaryFiles,
+    ) => {
+      setSaveState("saving");
+      try {
+        const persistedFiles = Object.fromEntries(
+          await Promise.all(
+            Object.entries(files).map(
+              async ([id, file]) =>
+                [
+                  id,
+                  {
+                    ...file,
+                    dataURL: (await uploadFile(file)) as typeof file.dataURL,
+                  },
+                ] as const,
+            ),
+          ),
+        ) as BinaryFiles;
+        const { serializeAsJSON } = await import("@excalidraw/excalidraw");
+        const snapshot = JSON.parse(
+          serializeAsJSON(elements, appState, persistedFiles, "local"),
+        ) as WhiteboardSnapshot;
+        await updateWhiteboard({
+          _id: whiteboardId,
+          snapshot: JSON.stringify(snapshot),
+          preview: getPreview(elements),
+        });
+        setSaveState("saved");
+      } catch (error) {
+        console.error("Failed to save whiteboard scene:", error);
+        setSaveState("error");
+      }
     },
-    [colorScheme, saveSnapshot],
+    700,
   );
 
-  useEffect(() => {
-    if (!isEditorReady) return;
-    if (hasLoadedSnapshotRef.current) return;
-    const editor = editorRef.current;
-    if (!editor || !whiteboard?.snapshot) return;
-
-    try {
-      loadSnapshot(editor.store, JSON.parse(whiteboard.snapshot));
-    } catch {
-      // A malformed legacy snapshot should not prevent a fresh board.
-    }
-    hasLoadedSnapshotRef.current = true;
-  }, [isEditorReady, whiteboard?.snapshot]);
-
-  useEffect(() => {
-    editorRef.current?.user.updateUserPreferences({ colorScheme });
-  }, [colorScheme]);
+  const handleChange = useCallback(
+    (
+      elements: readonly ExcalidrawElement[],
+      appState: AppState,
+      files: BinaryFiles,
+    ) => {
+      void saveScene(elements, appState, files);
+    },
+    [saveScene],
+  );
 
   useEffect(() => {
     if (!whiteboard?.title) return;
@@ -157,59 +165,46 @@ export default function WhiteboardPageClient({
 
   useEffect(
     () => () => {
-      saveSnapshot.flush();
+      void saveScene.flush();
     },
-    [saveSnapshot],
+    [saveScene],
   );
 
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        saveSnapshot.flush();
-      }
+      if (document.visibilityState === "hidden") void saveScene.flush();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () =>
       document.removeEventListener("visibilitychange", handleVisibilityChange);
-  }, [saveSnapshot]);
+  }, [saveScene]);
 
-  useEffect(() => {
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (saveState === "saving") {
-        e.preventDefault();
-      }
-    };
-    window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [saveState]);
-
-  const canvas = useMemo(
-    () => (
-      <Tldraw
-        key={whiteboardId}
-        colorScheme={colorScheme}
-        onMount={handleMount}
-        assets={assetStore}
-        components={{
-          MainMenu: null,
-          PageMenu: null,
-          QuickActions: null,
-        }}
-      />
-    ),
-    [colorScheme, handleMount, assetStore, whiteboardId],
-  );
-
-  if (!hasLoadedOnce) {
+  if (whiteboard === undefined) {
     return <div className="h-full min-h-[60vh] animate-pulse bg-card" />;
   }
 
   return (
-    <div className="whiteboard-canvas relative h-full min-h-[calc(100vh-4rem)] w-full overflow-hidden bg-background">
-      {canvas}
+    <div className="whiteboard-canvas relative h-full min-h-[calc(100vh-4rem)] min-w-full overflow-hidden bg-background">
+      <Excalidraw
+        key={whiteboardId}
+        initialData={parseSnapshot(whiteboard?.snapshot)}
+        onChange={handleChange}
+        theme={resolvedTheme === "dark" ? "dark" : "light"}
+        UIOptions={{
+          canvasActions: {
+            changeViewBackgroundColor: false,
+            clearCanvas: false,
+            export: false,
+            loadScene: false,
+            saveToActiveFile: false,
+            saveAsImage: false,
+            toggleTheme: false,
+          },
+        }}
+      />
       {saveState === "error" && (
         <div className="absolute bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-none border border-destructive bg-destructive/10 px-3 py-1.5 text-sm text-destructive">
-          Couldn't save your last change check your connection.
+          Couldn&apos;t save your last change. Check your connection.
         </div>
       )}
     </div>

--- a/components/advanced-editor.tsx
+++ b/components/advanced-editor.tsx
@@ -373,7 +373,7 @@ const TailwindAdvancedEditor = ({
             }}
             slotAfter={<ImageResizer />}
           >
-            <EditorCommand className="z-50 h-auto max-h-[330px] overflow-y-auto app-radius-lg border border-border bg-muted px-1 py-1 transition-all scroll-smooth [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
+            <EditorCommand className="z-50 h-auto max-h-[330px] overflow-y-auto app-radius-lg border border-border bg-card px-1 py-1 transition-all scroll-smooth [&::-webkit-scrollbar]:w-[0.4rem] [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
               <EditorCommandEmpty className="px-2 text-muted-foreground">
                 No results
               </EditorCommandEmpty>

--- a/components/generative/generative-menu-switch.tsx
+++ b/components/generative/generative-menu-switch.tsx
@@ -33,7 +33,7 @@ const GenerativeMenuSwitch = ({
           editor?.chain().unsetHighlight().run();
         },
       }}
-      className="flex w-fit max-w-[80vw] h-fit p-0.5 overflow-hidden app-radius-lg bg-muted border border-border shadow-xl"
+      className="flex w-fit max-w-[80vw] h-fit p-0.5 overflow-hidden app-radius-lg bg-card border border-border shadow-xl"
     >
       {open && <AISelector open={open} onOpenChange={onOpenChange} />}
       {!open && (

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -77,8 +77,8 @@ export default defineSchema({
     workingSpaceId: v.id("workingSpaces"),
     notesTableId: v.id("notesTables"),
     title: v.string(),
-    // A serialized tldraw editor snapshot. Keeping this with the board makes
-    // each canvas available wherever the owner signs in.
+    // A serialized Excalidraw scene. Keeping this with the board makes each
+    // canvas available wherever the owner signs in.
     snapshot: v.optional(v.string()),
     preview: v.optional(v.string()),
     createdAt: v.number(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notevo",
-  "version": "0.1.1",
+  "version": "14.0.0",
   "private": true,
   "scripts": {
     "dev": "npm-run-all --parallel dev:frontend dev:backend",
@@ -23,6 +23,7 @@
     "@auth/core": "^0.37.0",
     "@convex-dev/auth": "^0.0.77",
     "@elevenlabs/react": "^0.12.3",
+    "@excalidraw/excalidraw": "^0.18.1",
     "@hello-pangea/dnd": "^18.0.1",
     "@heroui/react-utils": "^2.1.8",
     "@heroui/shared-utils": "^2.1.7",


### PR DESCRIPTION
## changes

<img width="1558" height="930" alt="image" src="https://github.com/user-attachments/assets/a481012f-6724-47f0-8f1f-61c5b7c83395" />


* replace tldraw with Excalidraw as the whiteboard engine
* add Excalidraw styling and map its UI colors to the existing Notevo theme
* dynamically load Excalidraw on the client to avoid SSR issues
* update snapshot handling to persist Excalidraw scenes with elements, app state, and files
* add image upload handling through Convex storage and reuse pending uploads by file ID
* restore saved scenes through Excalidraw's `initialData`
* keep automatic debounced saving and flush pending saves when leaving or hiding the page
* hide Excalidraw actions that Notevo already handles, like exporting, loading scenes, and changing the canvas background
* customize the toolbar, properties panel, menus, colors, focus states, and mobile layout to fit Notevo
* update the whiteboard schema comments and add the Excalidraw dependency
* slightly clean up the editor and generative menu backgrounds to use `bg-card`

The whiteboard is moving from tldraw to Excalidraw to get a better fit for the drawing experience and the way we want to handle scene and image persistence.

The new setup also gives us more control over how Excalidraw's UI fits into Notevo instead of exposing its default actions and layout.

## better now

Whiteboards now use Excalidraw with proper scene persistence, image uploads, and Notevo-themed controls. Images added to a board can be uploaded to Convex storage and restored with the saved scene.

The UI also feels much more integrated with the rest of the app, while unnecessary Excalidraw actions are hidden so the whiteboard stays focused on the Notevo workflow.
